### PR TITLE
[NETSH] Increased functionality

### DIFF
--- a/base/applications/network/netsh/CMakeLists.txt
+++ b/base/applications/network/netsh/CMakeLists.txt
@@ -3,11 +3,15 @@ include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/conutils)
 spec2def(netsh.exe netsh.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
+    list.c
     context.c
     help.c
     helper.c
     interpreter.c
     netsh.c
+    stack.c
+    utility.c
+    hashtable.c
     precomp.h)
 
 add_executable(netsh ${SOURCE} netsh.rc ${CMAKE_CURRENT_BINARY_DIR}/netsh.def)

--- a/base/applications/network/netsh/context.c
+++ b/base/applications/network/netsh/context.c
@@ -3,6 +3,7 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell context management functions
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 /* INCLUDES *******************************************************************/
@@ -14,11 +15,204 @@
 
 /* GLOBALS ********************************************************************/
 
-PCONTEXT_ENTRY pRootContext = NULL;
-PCONTEXT_ENTRY pCurrentContext = NULL;
+static PCONTEXT_ENTRY _pRootContext = NULL;
+static PCONTEXT_ENTRY _pCurrentContext = NULL;
 
 /* FUNCTIONS ******************************************************************/
 
+PCONTEXT_ENTRY
+GetCurrentContext(VOID)
+{
+    return _pCurrentContext;
+}
+
+void
+SetCurrentContext(
+    PCONTEXT_ENTRY pContext)
+{
+    if (pContext)
+        _pCurrentContext = pContext;
+}
+
+PCONTEXT_ENTRY
+GetRootContext(VOID)
+{
+    return _pRootContext;
+}
+
+static
+void
+SetRootContext(
+    PCONTEXT_ENTRY pContext)
+{
+    if (pContext)
+        _pRootContext = pContext;
+}
+
+static 
+STACK *
+_GetContextStack()
+{
+    static STACK *pContextStack = NULL;
+    
+    if (pContextStack == NULL)
+        pContextStack = CreateStack();  
+        
+    return pContextStack;
+}
+
+/*
+Search through every context until we find one with a matching GUID
+or return NULL if we did not find anything
+*/
+
+
+static
+PCONTEXT_ENTRY
+GetContextFromGUID(
+    const GUID *guidHelper)
+{
+    DPRINT("%s()\n", __FUNCTION__);
+    PCONTEXT_ENTRY pCurrent = GetRootContext();
+    
+    if (pCurrent == NULL)
+        return NULL;
+        
+    if (guidHelper == NULL)
+        return NULL;
+        
+    STACK *stack = CreateStack();
+    
+    if (stack == NULL)
+        return NULL;
+        
+    // push the root node 
+    StackPush(stack, pCurrent);
+
+    while (!IsStackEmpty(stack)) {
+        PCONTEXT_ENTRY pCurrent = (PCONTEXT_ENTRY)StackPop(stack);
+        
+        // See if we have found a matching GUID
+        if ((pCurrent != NULL) && (IsEqualGUID(&pCurrent->Guid, guidHelper)))
+        {
+            DPRINT1("%s() Found context with supplied GUID\n", __FUNCTION__);
+            StackFree(stack, FALSE);
+            return pCurrent;
+        }
+        
+        // Push subcontexts onto the stack
+        if ((pCurrent != NULL) && (pCurrent->pSubContextHead != NULL))
+        {
+            PCONTEXT_ENTRY pSubcontext = pCurrent->pSubContextHead;
+            while (pSubcontext != NULL) 
+            {
+                StackPush(stack, pSubcontext);
+                pSubcontext = pSubcontext->pNext;
+            }
+        }
+        
+        // Push helpers to stack
+        if (pCurrent->pNext != NULL)
+        {
+            pCurrent = pCurrent->pNext;
+            
+            while (pCurrent)
+            {
+                StackPush(stack, pCurrent);
+                pCurrent = pCurrent->pNext;
+            }
+         }
+    }
+
+    DPRINT1("%s() No context found with supplied GUID\n", __FUNCTION__);
+    StackFree(stack, FALSE);
+    return NULL;
+}
+
+DWORD
+WINAPI
+AbortCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
+
+DWORD
+WINAPI
+AliasCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    BOOL bReturn = FALSE;
+    
+    // alias
+    if (dwArgCount == 1)
+    {
+        DisplayAliasTable();
+        return NO_ERROR;
+    }
+    
+    // alias <commamd>
+    // show alias entry in alias the table
+    if (dwArgCount == 2)
+    {
+        DisplayAliasEntry(argv[1], (wcslen(argv[1]) + 1) * sizeof(WCHAR));
+        return NO_ERROR;
+    }
+    
+    // todo check for built in command before adding
+    
+    wchar_t *pwszAliasValue = JoinStringsW(&argv[2], dwArgCount - 2, L" ");
+    
+    if (pwszAliasValue == NULL)
+    {
+        return GetLastError();
+    }
+    
+    wchar_t *pwszAlias = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, (wcslen(argv[1]) + 1) * sizeof(WCHAR));
+    
+    if (pwszAlias == NULL)
+    {
+        return GetLastError();
+    }
+    
+    wcscpy(pwszAlias, argv[1]);
+    bReturn = SetAliasEntry((PVOID)pwszAlias, (wcslen(argv[1]) + 1) * sizeof(WCHAR), (PVOID)pwszAliasValue);
+    
+    if (bReturn == TRUE)
+    {
+        // todo localize
+        ConPrintf(StdOut, L"Ok.\n\n");
+        return NO_ERROR;
+    }
+    
+    return GetLastError();
+}
+
+
+PCOMMAND_ENTRY
+AddGroupCommand(
+    PCOMMAND_GROUP pGroup,
+    LPCWSTR pwszCmdToken,
+    PFN_HANDLE_CMD pfnCmdHandler,
+    DWORD dwShortCmdHelpToken,
+    DWORD dwCmdHlpToken,
+    DWORD dwFlags,
+    PNS_OSVERSIONCHECK pOsVersionCheck,
+    HMODULE hModule);
+    
 PCONTEXT_ENTRY
 AddContext(
     PCONTEXT_ENTRY pParentContext,
@@ -104,7 +298,6 @@ AddContextCommand(
     }
 
     wcscpy((LPWSTR)pEntry->pwszCmdToken, pwszCmdToken);
-
     pEntry->pfnCmdHandler = pfnCmdHandler;
     pEntry->dwShortCmdHelpToken = dwShortCmdHelpToken;
     pEntry->dwCmdHlpToken = dwCmdHlpToken;
@@ -112,11 +305,13 @@ AddContextCommand(
 
     if (pContext->pCommandListHead == NULL && pContext->pCommandListTail == NULL)
     {
+        // insert the first node into the list
         pContext->pCommandListHead = pEntry;
         pContext->pCommandListTail = pEntry;
     }
     else
     {
+        // insert an entry at the end of a linked list
         pEntry->pPrev = pContext->pCommandListTail;
         pContext->pCommandListTail->pNext = pEntry;
         pContext->pCommandListTail = pEntry;
@@ -131,7 +326,12 @@ AddCommandGroup(
     PCONTEXT_ENTRY pContext,
     LPCWSTR pwszCmdGroupToken,
     DWORD dwShortCmdHelpToken,
-    DWORD dwFlags)
+    ULONG ulCmdGroupSize,
+    DWORD dwFlags,
+    PCMD_ENTRY pCmdGroup,
+    PNS_OSVERSIONCHECK pOsVersionCheck,
+    HMODULE hModule
+    )
 {
     PCOMMAND_GROUP pEntry;
 
@@ -149,22 +349,41 @@ AddCommandGroup(
         return NULL;
     }
 
+
     wcscpy((LPWSTR)pEntry->pwszCmdGroupToken, pwszCmdGroupToken);
     pEntry->dwShortCmdHelpToken = dwShortCmdHelpToken;
+    pEntry->ulCmdGroupSize = ulCmdGroupSize;
     pEntry->dwFlags = dwFlags;
+    pEntry->pOsVersionCheck = pOsVersionCheck;
+    pEntry->hModule = hModule;
 
     if (pContext->pGroupListHead == NULL && pContext->pGroupListTail == NULL)
     {
+        // insert the first node into the list
         pContext->pGroupListHead = pEntry;
         pContext->pGroupListTail = pEntry;
     }
     else
     {
+       // insert node at end of list for command group entry
         pEntry->pPrev = pContext->pGroupListTail;
         pContext->pGroupListTail->pNext = pEntry;
         pContext->pGroupListTail = pEntry;
     }
-
+    
+    // Add the commands to the group
+    for (size_t i = 0; i < pEntry->ulCmdGroupSize; i++)
+    {
+        DPRINT1("%s Adding group command: %ls\n", __FUNCTION__, pCmdGroup[i].pwszCmdToken);
+        AddGroupCommand(pEntry, 
+                        pCmdGroup[i].pwszCmdToken, 
+                        pCmdGroup[i].pfnCmdHandler, 
+                        pCmdGroup[i].dwShortCmdHelpToken,
+                        pCmdGroup[i].dwCmdHlpToken, 
+                        pCmdGroup[i].dwFlags, 
+                        pCmdGroup[i].pOsVersionCheck,
+                        pEntry->hModule);
+    }
     return pEntry;
 }
 
@@ -176,7 +395,9 @@ AddGroupCommand(
     PFN_HANDLE_CMD pfnCmdHandler,
     DWORD dwShortCmdHelpToken,
     DWORD dwCmdHlpToken,
-    DWORD dwFlags)
+    DWORD dwFlags,
+    PNS_OSVERSIONCHECK pOsVersionCheck,
+    HMODULE hModule)
 {
     PCOMMAND_ENTRY pEntry;
 
@@ -196,13 +417,14 @@ AddGroupCommand(
         HeapFree(GetProcessHeap(), 0, pEntry);
         return NULL;
     }
-
+    
     wcscpy((LPWSTR)pEntry->pwszCmdToken, pwszCmdToken);
-
     pEntry->pfnCmdHandler = pfnCmdHandler;
     pEntry->dwShortCmdHelpToken = dwShortCmdHelpToken;
     pEntry->dwCmdHlpToken = dwCmdHlpToken;
     pEntry->dwFlags = dwFlags;
+    pEntry->pOsVersionCheck = pOsVersionCheck;
+    pEntry->hModule = hModule;
 
     if (pGroup->pCommandListHead == NULL && pGroup->pCommandListTail == NULL)
     {
@@ -220,6 +442,21 @@ AddGroupCommand(
 }
 
 
+DWORD
+WINAPI
+CommitCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
+
 VOID
 DeleteContext(
     PWSTR pszName)
@@ -228,6 +465,20 @@ DeleteContext(
     /* Delete the context */
 }
 
+DWORD
+WINAPI
+DumpCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
 
 DWORD
 WINAPI
@@ -240,12 +491,28 @@ UpCommand(
     LPCVOID pvData,
     BOOL *pbDone)
 {
-    if (pCurrentContext != pRootContext)
-        pCurrentContext = pCurrentContext->pParentContext;
+    PCONTEXT_ENTRY pCurrentContext = GetCurrentContext();
 
-    return 0;
+    if (pCurrentContext != GetRootContext())
+        SetCurrentContext(pCurrentContext->pParentContext);
+
+    return NO_ERROR;
 }
 
+DWORD
+WINAPI
+ExecCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
 
 DWORD
 WINAPI
@@ -259,9 +526,185 @@ ExitCommand(
     BOOL *pbDone)
 {
     *pbDone = TRUE;
-    return 0;
+    return NO_ERROR;
 }
 
+/*
+Pushes the currerent context onto the stack
+and optionally runs a command
+as specified by the optional arguments
+*/
+DWORD
+WINAPI
+PushdCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{   
+    PCONTEXT_ENTRY pCurrentContext = GetCurrentContext();
+    
+    if (_GetContextStack() == NULL)
+    {
+        DPRINT1("%s ContextStack is NULL!\n", __FUNCTION__);
+        return 1; 
+    }
+    
+    if (pCurrentContext)
+    {
+        StackPush(_GetContextStack(), pCurrentContext);
+    }
+    
+    // if pushd was called without arguments
+    if (dwArgCount == 1)
+        return NO_ERROR;
+
+    DPRINT1("%s argv[1]: %ls (dwArgCount - dwCurrentIndex): %lu\n", __FUNCTION__, argv[1], dwArgCount - dwCurrentIndex);
+    // call interpret command with the rest of the parameters
+    InterpretCommand(&argv[1], dwArgCount - dwCurrentIndex);
+    
+    return NO_ERROR;
+}
+
+/*
+Pops a context off of the stack
+popd ignores any arguments supplied to it,
+and does not produce errors when supplied
+*/
+DWORD
+WINAPI
+PopdCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    PCONTEXT_ENTRY pTempContext = NULL;
+    
+    if (_GetContextStack() == NULL)
+    {
+        DPRINT1("%s ContextStack is NULL!\n", __FUNCTION__);
+        return 1; 
+    }
+         
+    if (IsStackEmpty(_GetContextStack()))
+        return NO_ERROR;
+    
+     pTempContext = StackPop(_GetContextStack());
+     
+     if (pTempContext)
+     {
+         SetCurrentContext(pTempContext);
+         return NO_ERROR;
+     }
+     
+
+    
+    // TODO is there a better error message? 
+    // How does netsh handle a null pointer on the context stack? 
+    // Does it?
+    return 1;//ERROR_BAD_STACK; 
+}
+
+DWORD
+WINAPI
+OfflineCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    SetMode(FALSE);
+    return NO_ERROR;
+}
+
+DWORD
+WINAPI
+OnlineCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    SetMode(TRUE);
+    return NO_ERROR;
+}
+
+DWORD
+WINAPI
+SetMachineCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
+
+
+DWORD
+WINAPI
+SetModeCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+    ConPrintf(StdOut, L"TODO NOT IMPLEMENTED...\n");
+    return NO_ERROR;
+}
+
+
+DWORD
+WINAPI
+UnaliasCommand(
+    LPCWSTR pwszMachine,
+    LPWSTR *argv,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
+    DWORD dwFlags,
+    LPCVOID pvData,
+    BOOL *pbDone)
+{
+        BOOL bReturn = FALSE;
+    
+    if (dwArgCount != 2)
+    {
+        // todo show error message
+        // and display help
+        return NO_ERROR;
+    }
+    
+    bReturn = DeleteAliasEntry(argv[1], (wcslen(argv[1]) + 1) * sizeof(WCHAR));
+    
+    if (bReturn == TRUE)
+    {
+        // todo localize
+        ConPrintf(StdOut, L"Ok.\n\n");
+        return NO_ERROR;
+    }
+    
+    return GetLastError();
+}
 
 DWORD
 WINAPI
@@ -282,41 +725,62 @@ BOOL
 CreateRootContext(VOID)
 {
     PCOMMAND_GROUP pGroup;
-
-    pRootContext = AddContext(NULL, NULL, NULL);
+    PCONTEXT_ENTRY pRootContext = NULL;
+    
+    pRootContext = AddContext(NULL, L"netsh", NULL);
     DPRINT1("pRootContext: %p\n", pRootContext);
+    
     if (pRootContext == NULL)
         return FALSE;
 
     pRootContext->hModule = GetModuleHandle(NULL);
 
-    AddContextCommand(pRootContext, L"..",   UpCommand, IDS_HLP_UP, IDS_HLP_UP_EX, 0);
-    AddContextCommand(pRootContext, L"?",    HelpCommand, IDS_HLP_HELP, IDS_HLP_HELP_EX, 0);
-    AddContextCommand(pRootContext, L"bye",  ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
-    AddContextCommand(pRootContext, L"exit", ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
-    AddContextCommand(pRootContext, L"help", HelpCommand, IDS_HLP_HELP, IDS_HLP_HELP_EX, 0);
-    AddContextCommand(pRootContext, L"quit", ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
-
-    pGroup = AddCommandGroup(pRootContext, L"add", IDS_HLP_GROUP_ADD, 0);
+    AddContextCommand(pRootContext, L"..",      UpCommand, IDS_HLP_UP, IDS_HLP_UP_EX, 0);
+    AddContextCommand(pRootContext, L"?",       HelpCommand, IDS_HLP_HELP, IDS_HLP_HELP_EX, 0);
+    AddContextCommand(pRootContext, L"abort",   AbortCommand, IDS_HLP_ABORT, IDS_HLP_ABORT_EX, 0);
+    AddContextCommand(pRootContext, L"alias",   AliasCommand, IDS_HLP_ALIAS, IDS_HLP_ALIAS_EX, 0);
+    AddContextCommand(pRootContext, L"bye",     ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
+    AddContextCommand(pRootContext, L"commit",  CommitCommand, IDS_HLP_COMMIT, IDS_HLP_COMMIT_EX, 0);
+    AddContextCommand(pRootContext, L"dump",    DumpCommand, IDS_HLP_DUMP, IDS_HLP_DUMP_EX, 0);
+    AddContextCommand(pRootContext, L"exec",    ExecCommand, IDS_HLP_EXEC, IDS_HLP_EXEC_EX, CMD_FLAG_PRIVATE);
+    AddContextCommand(pRootContext, L"exit",    ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
+    AddContextCommand(pRootContext, L"help",    HelpCommand, IDS_HLP_HELP, IDS_HLP_HELP_EX, 0);
+    AddContextCommand(pRootContext, L"quit",    ExitCommand, IDS_HLP_EXIT, IDS_HLP_EXIT_EX, 0);
+    AddContextCommand(pRootContext, L"pushd",   PushdCommand, IDS_HLP_PUSHD, IDS_HLP_PUSHD_EX, 0);
+    AddContextCommand(pRootContext, L"popd",    PopdCommand, IDS_HLP_POPD, IDS_HLP_POPD_EX, 0);
+    AddContextCommand(pRootContext, L"offline", OfflineCommand, IDS_HLP_OFFLINE, IDS_HLP_OFFLINE_EX, 0);
+    AddContextCommand(pRootContext, L"online",  OnlineCommand, IDS_HLP_ONLINE, IDS_HLP_ONLINE_EX, 0);
+    AddContextCommand(pRootContext, L"unalias", UnaliasCommand, IDS_HLP_UNALIAS, IDS_HLP_UNALIAS_EX, 0);
+    
+    pGroup = AddCommandGroup(pRootContext, L"add", IDS_HLP_GROUP_ADD, 0, 0, NULL, NULL, pRootContext->hModule);
     if (pGroup)
     {
-        AddGroupCommand(pGroup, L"helper", AddHelperCommand, IDS_HLP_ADD_HELPER, IDS_HLP_ADD_HELPER_EX, 0);
+        AddGroupCommand(pGroup, L"helper", AddHelperCommand, IDS_HLP_ADD_HELPER, IDS_HLP_ADD_HELPER_EX, 0, NULL, pRootContext->hModule);
     }
 
-    pGroup = AddCommandGroup(pRootContext, L"delete", IDS_HLP_GROUP_DELETE, 0);
+    pGroup = AddCommandGroup(pRootContext, L"delete", IDS_HLP_GROUP_DELETE, 0, 0, NULL, NULL, pRootContext->hModule);
     if (pGroup)
     {
-        AddGroupCommand(pGroup, L"helper", DeleteHelperCommand, IDS_HLP_DEL_HELPER, IDS_HLP_DEL_HELPER_EX, 0);
+        AddGroupCommand(pGroup, L"helper", DeleteHelperCommand, IDS_HLP_DEL_HELPER, IDS_HLP_DEL_HELPER_EX, 0, NULL, pRootContext->hModule);
     }
-
-    pGroup = AddCommandGroup(pRootContext, L"show", IDS_HLP_GROUP_SHOW, 0);
+    
+    pGroup = AddCommandGroup(pRootContext, L"set", IDS_HLP_GROUP_SET, 0, 0, NULL, NULL, pRootContext->hModule);
     if (pGroup)
     {
-        AddGroupCommand(pGroup, L"helper", ShowHelperCommand, IDS_HLP_SHOW_HELPER, IDS_HLP_SHOW_HELPER_EX, 0);
+        AddGroupCommand(pGroup, L"machine", SetMachineCommand, IDS_HLP_SET_MACHINE, IDS_HLP_SET_MACHINE_EX, 0, NULL, pRootContext->hModule);
+        AddGroupCommand(pGroup, L"mode", SetModeCommand, IDS_HLP_SET_MODE, IDS_HLP_SET_MODE_EX, 0, NULL, pRootContext->hModule);
+    }
+    
+    pGroup = AddCommandGroup(pRootContext, L"show", IDS_HLP_GROUP_SHOW, 0, 0, NULL, NULL, pRootContext->hModule);
+    if (pGroup)
+    {
+        //AddGroupCommand(pGroup, L"alias", ShowHelperCommand, IDS_HLP_SHOW_HELPER, IDS_HLP_SHOW_HELPER_EX, 0, NULL, pRootContext->hModule);
+        //AddGroupCommand(pGroup, L"mode", ShowHelperCommand, IDS_HLP_SHOW_HELPER, IDS_HLP_SHOW_HELPER_EX, 0, NULL, pRootContext->hModule);
+        AddGroupCommand(pGroup, L"helper", ShowHelperCommand, IDS_HLP_SHOW_HELPER, IDS_HLP_SHOW_HELPER_EX, 0, NULL, pRootContext->hModule);
     }
 
-    pCurrentContext = pRootContext;
-
+    SetCurrentContext(pRootContext);
+    SetRootContext(pRootContext);
     return TRUE;
 }
 
@@ -326,10 +790,10 @@ WINAPI
 RegisterContext(
     _In_ const NS_CONTEXT_ATTRIBUTES *pChildContext)
 {
-    PCONTEXT_ENTRY pContext;
+    PHELPER_ENTRY pHelper = NULL;
+    PCONTEXT_ENTRY pContext = NULL;
     DWORD i;
 
-    DPRINT1("RegisterContext(%p)\n", pChildContext);
     if (pChildContext == NULL)
     {
         DPRINT1("Invalid child context!\n");
@@ -341,17 +805,89 @@ RegisterContext(
         (wcschr(pChildContext->pwszContext, L' ') != 0) ||
         (wcschr(pChildContext->pwszContext, L'=') != 0))
     {
-        DPRINT1("Invalid context name!\n");
-        return ERROR_INVALID_PARAMETER;
+        DPRINT1("%s Invalid context name!\n", __FUNCTION__);
+            return ERROR_INVALID_PARAMETER;
     }
 
+    if (GetContextFromGUID(&pChildContext->guidHelper) != NULL)
+    {
+        DPRINT1("%s GUID already exists\n", __FUNCTION__);
+        return ERROR_CONTEXT_ALREADY_REGISTERED;
+    }
+    
     DPRINT1("Name: %S\n", pChildContext->pwszContext);
-
-    pContext = AddContext(pRootContext, pChildContext->pwszContext, (GUID*)&pChildContext->guidHelper);
+    
+    /* Attempt to find the module handle to the helper DLL so we can 
+    load string resources from it later */
+    pHelper = FindHelper(&pChildContext->guidHelper);
+    DPRINT1("%s pHelper address is : 0x%p\n", __FUNCTION__, pHelper);
+    
+    if (pHelper != NULL)
+    {
+        // if we have a parent GUID try and find its context *********************************************************
+        DPRINT1("%s if (pHelper->pguidParentHelper)\n", __FUNCTION__);
+        if (pHelper->pguidParentHelper != NULL)
+        {
+            DPRINT1("%s if (pHelper->pguidParentHelper)\n", __FUNCTION__);
+            PCONTEXT_ENTRY pTempContext = GetContextFromGUID(pHelper->pguidParentHelper);
+            if (pTempContext != NULL)
+            {
+                DPRINT1("%s Found parent context.\n", __FUNCTION__);
+                pContext = AddContext(pTempContext, pChildContext->pwszContext, (GUID*)&pChildContext->guidHelper);
+            }
+            else
+            {
+                DPRINT1("%s Cannot find parent context GUID!\n", __FUNCTION__);
+                pContext = AddContext(GetRootContext(), pChildContext->pwszContext, (GUID*)&pChildContext->guidHelper);
+            }
+            
+        }
+        // we dont have a parent so add to the root context
+        else
+        {
+            DPRINT1("%s Dont have a parent context\n", __FUNCTION__);
+            pContext = AddContext(GetRootContext(), pChildContext->pwszContext, (GUID*)&pChildContext->guidHelper);
+            
+        }
+        //*************************************************************************************************************
+        
+        // find a handle to the module ************************************************************************************
+        DPRINT1("%s pHelper is not NULL\n", __FUNCTION__);
+        if (pHelper->pDllEntry != NULL)
+        {
+            if(pHelper->pDllEntry->hModule != NULL)
+            {
+                DPRINT1("%s pContext->hModule = pHelper->pDllEntry->hModule;\n", __FUNCTION__);
+                pContext->hModule = pHelper->pDllEntry->hModule;
+                DPRINT1("%s AFTER pContext->hModule = pHelper->pDllEntry->hModule;\n", __FUNCTION__);
+            }
+            else
+            {
+                DPRINT1("%s pHelper->pDllEntry->hModule is NULL\n", __FUNCTION__);
+                pContext->hModule = NULL;
+            }
+        }
+        else
+        {
+            DPRINT1("%s pHelper->pDllEntry is NULL\n", __FUNCTION__);
+            pContext->hModule = NULL;
+        }
+        //******************************************************************************************************************
+    }
+    else
+    {
+        pContext = AddContext(GetRootContext(), pChildContext->pwszContext, (GUID*)&pChildContext->guidHelper);
+        DPRINT("%s pHelper is NULL\n", __FUNCTION__);
+        pContext->hModule = NULL;
+    }
+    //*************************************************************************
+    
     if (pContext != NULL)
     {
+        // Add all top commands
         for (i = 0; i < pChildContext->ulNumTopCmds; i++)
         {
+            DPRINT1("%s pChildContext->pTopCmds[i].pwszCmdToken: %ls\n", __FUNCTION__, pChildContext->pTopCmds[i].pwszCmdToken);
             AddContextCommand(pContext,
                 pChildContext->pTopCmds[i].pwszCmdToken,
                 pChildContext->pTopCmds[i].pfnCmdHandler,
@@ -363,11 +899,17 @@ RegisterContext(
         /* Add command groups */
         for (i = 0; i < pChildContext->ulNumGroups; i++)
         {
+            DPRINT1("%s Adding command group: %ls\n", __FUNCTION__, pChildContext->pCmdGroups[i].pwszCmdGroupToken);
             AddCommandGroup(pContext,
-                pChildContext->pCmdGroups[i].pwszCmdGroupToken,
-                pChildContext->pCmdGroups[i].dwShortCmdHelpToken,
-                pChildContext->pCmdGroups[i].dwFlags);
+                            pChildContext->pCmdGroups[i].pwszCmdGroupToken,
+                            pChildContext->pCmdGroups[i].dwShortCmdHelpToken,
+                            pChildContext->pCmdGroups[i].ulCmdGroupSize,
+                            pChildContext->pCmdGroups[i].dwFlags,
+                            pChildContext->pCmdGroups[i].pCmdGroup,
+                            pChildContext->pCmdGroups[i].pOsVersionCheck,
+                            pContext->hModule);
         }
+                
     }
 
     return ERROR_SUCCESS;

--- a/base/applications/network/netsh/hashtable.c
+++ b/base/applications/network/netsh/hashtable.c
@@ -1,0 +1,904 @@
+/*
+ * PROJECT:    Hash Table
+ * LICENSE:    MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:    Hash Table main file
+ * COPYRIGHT:  Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
+ */
+
+//#define HASH_TABLE_UNIT_TEST
+#define NDEBUG
+#include <debug.h>
+
+#ifdef HASH_TABLE_UNIT_TEST
+#define STATIC
+#else
+#define STATIC static
+#include "hashtable.h"
+#endif
+
+typedef struct _INTERNAL_HASH_TABLE
+{
+    size_t nNumberOfEntries;
+    size_t nNumberOfBuckets;
+    size_t nNumberOfBucketsUsed;
+    PHASH_ENTRY* Buckets;
+    DOUBLE dLoadFactor;
+}INTERNAL_HASH_TABLE, *PINTERNAL_HASH_TABLE;
+
+#ifndef HASH_TABLE_UNIT_TEST
+typedef struct _HASH_TABLE_ITERATOR
+{
+    PHASH_TABLE pHashTable;
+    PHASH_ENTRY pHashEntry;
+    SIZE_T nIndex;
+} HASH_TABLE_ITERATOR, *PHASH_TABLE_ITERATOR;
+#endif
+
+STATIC
+PHASH_ENTRY
+_FindEntry(
+    struct _HASH_TABLE* self,
+    PVOID pKey,
+    SIZE_T nKeyLength);
+
+STATIC
+BOOL
+_HashTableFreeEntry(
+    PHASH_ENTRY pHashEntry,
+    BOOL bFreeKey,
+    BOOL bFreeValue);
+// *********************************************************************
+
+STATIC
+BOOL 
+IsPrime(SIZE_T n)
+{
+    // 0 or 1 are not prime
+    if (n <= 1)
+    {
+        return FALSE;
+    }
+
+    // 2 and 3 are prime
+    if (n <= 3)
+    {
+        return TRUE;
+    }
+
+    // Eliminate multiples of 2 and 3
+    if ((n % 2 == 0) || (n % 3 == 0))
+    {
+        return FALSE; 
+    }
+
+    // Only check up to the square root of n
+    SIZE_T limit = (SIZE_T)sqrt(n); 
+
+    // Check for factors of the form 6k ± 1
+    for (SIZE_T i = 5; i <= limit; i += 6)
+    {
+        if (n % i == 0 || n % (i + 2) == 0)
+        {
+            return FALSE; // Check both 6k - 1 and 6k + 1 forms
+        }
+    }
+
+    return TRUE;
+}
+
+
+// Find the closest prime number
+STATIC
+SIZE_T 
+FindClosestPrime(
+    SIZE_T number)
+{
+    // If we are at the maximum value, return it directly
+    if (number == SIZE_MAX)
+    {
+        return SIZE_MAX; 
+    }
+
+    SIZE_T candidate = number; // Start from the next number
+    while (TRUE) {
+        if (IsPrime(candidate))
+        {
+            return candidate; // Return the first prime found
+        }
+
+        // Prevent overflow
+        if (candidate == SIZE_MAX)
+            break;
+        
+        candidate++;
+    }
+
+    return SIZE_MAX; 
+}
+
+
+STATIC
+DWORD 
+_Fnv1aHash32(
+    PVOID data, 
+    SIZE_T data_length)
+{
+    if (data == NULL || data_length == 0)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+
+    DWORD hash = 0x811c9dc5;
+    DWORD FNV_prime = 0x01000193;
+
+    unsigned char* c_data = (unsigned char*)data;
+    
+    for (size_t index = 0; index < data_length; index++)
+    {
+        hash ^= c_data[index];
+        hash *= FNV_prime;
+    }
+
+    return hash;
+}
+
+/**
+ * @brief Deletes an entry.
+ *
+ * This function deletes an entry in @p self by searching for a key @p pKey.
+ * The code does not free any memory allocated in the Bucket array, but it
+ * will free either the key or value as specified by @p bFreeKey and @p FreeValue.
+ * If the entry is a node in a linked list, the memory that holds the node will be
+ * freed.
+ *
+ * @param[in] self
+ * Contains a pointer to the current HASH_tABLE structure.
+ *
+ * @param[in] pKey
+ * The key to hash and use as an entry point into the hash table.
+ *
+ * @param[in] nKeyLength
+ * The length of pKey.
+ *
+ * @param[in] bFreeKey
+ * If TRUE, _DeleteEntry will attempt to free the memory used by pKey in the HASH_ENTRY
+ *
+ * @param[in] bFreeValue
+ * If TRUE, _DeleteEntry will attempt to free the memory used by pValue in the HASH_ENTRY
+ * 
+ * @return
+ * TRUE on success and FALSE on failure. Check GetLastError for more detailed information.
+ * GetLastError returns the following:
+ * STATUS_SUCCESS in case of success.
+ * ERROR_INVALID_PARAMETER if the input arguments are invalid.
+ * ERROR_INVALID_HANDLE if pInternal is NULL.
+ * ERROR_NO_MATCH if the key cannot be found.
+ * 
+ **/
+STATIC
+BOOL
+_DeleteEntry(
+    _In_ struct _HASH_TABLE* self, 
+    _In_ PVOID pKey,
+    _In_ SIZE_T nKeyLength,
+    _In_ BOOL bFreeKey,
+    _In_ BOOL bFreeValue)
+{
+    DWORD dwHash = 0;
+    SIZE_T nIndex = 0;
+    PHASH_ENTRY pHashEntry = NULL;
+    PHASH_ENTRY pParentHashEntry = NULL;
+    BOOL bIsNode = FALSE;
+
+    if ((self == NULL)
+        || (pKey == NULL)
+        || (nKeyLength == 0))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = self->pInternal;
+
+    if (self->pInternal == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return FALSE;
+    }
+
+    dwHash = _Fnv1aHash32(pKey, nKeyLength);
+    nIndex = dwHash % pInternalHashTable->nNumberOfBuckets;
+
+    pHashEntry = pInternalHashTable->Buckets[nIndex];
+
+    if (pHashEntry != NULL && pHashEntry->pNext == NULL)
+        pInternalHashTable->nNumberOfBucketsUsed--;
+
+    if (pHashEntry != NULL)
+    {
+        // follow the linked list until we find a key
+        while (pHashEntry)
+        {
+            // if the key lengths match we can compare
+            // the key to see if they match
+            if (pHashEntry->nKeyLength == nKeyLength)
+            {
+                if (memcmp(pHashEntry->pKey, pKey, nKeyLength) == 0)
+                {
+                    // Remove the link in the chain
+                    // if the node has a parrent
+                    if (pParentHashEntry != NULL)
+                    {
+                        pParentHashEntry->pNext = pHashEntry->pNext;
+                        bIsNode = TRUE;
+                    }
+                    // we are at the head of the linked list found inside
+                    // of this bucket
+                    else
+                    {
+                        pInternalHashTable->Buckets[nIndex] = pHashEntry->pNext;
+                    }
+                    break;
+                }
+            }
+            pParentHashEntry = pHashEntry;
+            pHashEntry = pHashEntry->pNext;
+        }
+    }
+
+    
+    // if the entry is not null then we have found the correct key
+    if (pHashEntry)
+    {
+        BOOL bFreeSuccessful = TRUE;
+
+        if (bFreeKey == TRUE)
+        {
+            if (HeapFree(GetProcessHeap(), 0, pHashEntry->pKey) == 0)
+                bFreeSuccessful = FALSE;
+        }
+
+        if (bFreeValue == TRUE)
+        {
+            if (HeapFree(GetProcessHeap(), 0, pHashEntry->pValue) == 0)
+                bFreeSuccessful = FALSE;
+        }
+
+        pHashEntry->bIsFull = FALSE;
+        pHashEntry->nKeyLength = 0;
+        pInternalHashTable->nNumberOfEntries--;
+        
+        if (bIsNode == TRUE)
+        {
+            if (HeapFree(GetProcessHeap(), 0, pHashEntry) == 0)
+                bFreeSuccessful = FALSE;
+        }
+
+        // Check if any if the HeapFree calls failed
+        if (bFreeSuccessful == FALSE)
+        {
+            return FALSE;
+        }
+         
+        SetLastError(ERROR_SUCCESS);
+        return TRUE;
+    }
+    
+    // key does not exist
+    SetLastError(ERROR_NO_MATCH);
+    return FALSE;
+}
+
+
+STATIC
+BOOL
+_HashTableGetEntryCleanup(
+    PHASH_TABLE_ITERATOR *sIterator)
+{
+    HeapFree(GetProcessHeap(), 0, *sIterator);
+    *sIterator = NULL;
+    SetLastError(ERROR_NO_MORE_ITEMS);
+    return FALSE;
+}
+
+
+STATIC
+BOOL
+_HashTableGetNextEntry(
+    PHASH_TABLE_ITERATOR *sIterator,
+    PHASH_ENTRY *pHashEntry)
+{
+    if (sIterator == NULL || *sIterator == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = (*sIterator)->pHashTable->pInternal;
+    // check if we have a linked list to work with
+    if ((*sIterator)->pHashEntry->pNext == NULL)
+    {
+        // iterate the entries until we find the next slot
+        for (size_t index = (*sIterator)->nIndex + 1; index < pInternalHashTable->nNumberOfBuckets; index++)
+        {
+            // make sure the entry exists first
+            if ((pInternalHashTable->Buckets[index] != NULL )
+                && (pInternalHashTable->Buckets[index]->bIsFull == TRUE))
+            {
+                // update the find entry structure
+                (*sIterator)->nIndex = index;
+                (*sIterator)->pHashEntry = pInternalHashTable->Buckets[index];
+                // somthing bad has happened if this is true
+                if ((*sIterator)->pHashEntry == NULL)
+                {
+                    *pHashEntry = NULL;
+                    return _HashTableGetEntryCleanup(sIterator);
+                }
+                // we found what we came here for
+                *pHashEntry = (*sIterator)->pHashEntry;
+                SetLastError(ERROR_SUCCESS);
+                return TRUE;
+            }
+
+        }
+        // there are no more entries to process so we can cleanup
+        *pHashEntry = NULL;
+        return _HashTableGetEntryCleanup(sIterator);
+    }
+    // we are in a linked list
+    else
+    {
+        (*sIterator)->pHashEntry = (*sIterator)->pHashEntry->pNext;
+        *pHashEntry = (*sIterator)->pHashEntry;
+    }
+
+    // if we made it here all is well
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+}
+
+
+STATIC
+PHASH_TABLE_ITERATOR
+_HashTableGetFirstEntry(
+    PHASH_TABLE pHashTable,
+    PHASH_ENTRY *pHashEntry)
+{
+    if (pHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return NULL;
+    }
+
+    if (pHashTable->pInternal == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return NULL;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = pHashTable->pInternal;
+    PHASH_TABLE_ITERATOR sIterator = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HASH_TABLE_ITERATOR));
+    
+    if (sIterator == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return NULL;
+    }
+
+    sIterator->pHashTable = pHashTable;
+    // find a bucket that is being used
+    for (size_t index = 0; index < pInternalHashTable->nNumberOfBuckets; index++)
+    {
+        // make sure are bucket exists and is not empty
+        if (pInternalHashTable->Buckets[index] != NULL 
+            && pInternalHashTable->Buckets[index]->bIsFull == TRUE)
+        {
+            // update the iterator to contain the newest entry
+            sIterator->nIndex = index;
+            sIterator->pHashEntry = pInternalHashTable->Buckets[index];
+            break;
+        }
+
+    }
+    
+    // set pHashEntry
+    *pHashEntry = sIterator->pHashEntry;
+
+    if (sIterator->pHashEntry == NULL)
+    {
+        _HashTableGetEntryCleanup(&sIterator);
+        return NULL;
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    return sIterator;
+}
+
+
+STATIC
+BOOL
+_ReHashTableEntries(
+    PHASH_TABLE pCurrentHashTable, 
+    PHASH_TABLE pNewHashTable)
+{
+    if (pCurrentHashTable == NULL || pNewHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    PHASH_ENTRY pHashEntry = NULL;
+    PHASH_TABLE_ITERATOR sIterator = _HashTableGetFirstEntry(pCurrentHashTable, &pHashEntry);
+    
+    while (pHashEntry)
+    {
+        pNewHashTable->SetEntry(&pNewHashTable, 
+            pHashEntry->pKey, 
+            pHashEntry->nKeyLength,
+            pHashEntry->pValue);
+
+        _HashTableGetNextEntry(&sIterator, &pHashEntry);
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+}
+
+
+STATIC
+BOOL
+_HashTableExpand(PHASH_TABLE *pHashTable)
+{
+    if (pHashTable == NULL || *pHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    PHASH_TABLE pTempHashTable = NULL;
+    PHASH_TABLE pNewHashTable = NULL;
+    PINTERNAL_HASH_TABLE pInternalHashTable = (*pHashTable)->pInternal;
+
+    if (pInternalHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return FALSE;
+    }
+
+    size_t nNewSize = FindClosestPrime((SIZE_T)(pInternalHashTable->nNumberOfEntries 
+                                             / pInternalHashTable->dLoadFactor));
+    pNewHashTable = CreateHashTable(nNewSize, pInternalHashTable->dLoadFactor);
+
+    // see if the allocation was successful
+    if (pNewHashTable == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return FALSE;
+    }
+
+    // rehash all of the keys found in pHashTable and store them in pNewHashTable
+    _ReHashTableEntries((*pHashTable), pNewHashTable);
+   
+    pTempHashTable = *pHashTable;
+    *pHashTable = pNewHashTable;
+    // free the old hash table
+    FreeHashTable(&pTempHashTable, FALSE, FALSE);
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+
+}
+
+
+STATIC
+SIZE_T _GetNumberOfEntries(
+    struct _HASH_TABLE* self)
+{
+    if (self == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return 0;
+    }
+
+    if (self->pInternal == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return 0;
+    }
+  
+    SetLastError(ERROR_SUCCESS);
+    return ((PINTERNAL_HASH_TABLE)self->pInternal)->nNumberOfEntries;
+}
+
+
+STATIC
+PHASH_ENTRY
+_CreateHashEntry(PVOID pKey, SIZE_T nKeyLength, PVOID pValue)
+{
+    if (pKey == NULL 
+        || nKeyLength == 0
+        || pValue == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return NULL;
+    }
+
+    PHASH_ENTRY pHashEntry = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HASH_ENTRY));
+    if (pHashEntry == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return FALSE;
+    }
+
+    pHashEntry->bIsFull = TRUE;
+    pHashEntry->pValue = pValue;
+    pHashEntry->pKey = pKey;
+    pHashEntry->nKeyLength = nKeyLength;
+
+    SetLastError(ERROR_SUCCESS);
+    return pHashEntry;
+}
+
+
+STATIC 
+BOOL
+_SetEntry(
+    struct _HASH_TABLE** self,
+    PVOID pKey,
+    SIZE_T nKeyLength,
+    PVOID pValue)
+{
+    DWORD dwHash = 0;
+    SIZE_T nIndex = 0;
+
+    if (self == NULL
+        || *self == NULL
+        || (nKeyLength == 0)
+        || (pValue == NULL)
+        || (pKey == NULL))
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    
+    PINTERNAL_HASH_TABLE pInternalHashTable = (*self)->pInternal;
+
+    if (pInternalHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return FALSE;
+    }
+
+    if (pInternalHashTable->nNumberOfBuckets == 0)
+        return FALSE; 
+  
+
+   dwHash = _Fnv1aHash32(pKey, nKeyLength);
+   nIndex = dwHash % pInternalHashTable->nNumberOfBuckets;
+
+    //printf("dwHash: 0x%x nIndex: %zu  pKey: %ls\n", dwHash, nIndex, (wchar_t *)pKey);
+    if (pInternalHashTable->Buckets[nIndex] != NULL)
+    {
+        // if the bucket is empty fill it
+        if (pInternalHashTable->Buckets[nIndex]->bIsFull == FALSE)
+        {
+            pInternalHashTable->Buckets[nIndex]->pValue = pValue;
+            pInternalHashTable->Buckets[nIndex]->bIsFull = TRUE;
+            pInternalHashTable->Buckets[nIndex]->pKey = pKey;
+            pInternalHashTable->Buckets[nIndex]->nKeyLength = nKeyLength;
+            pInternalHashTable->nNumberOfBucketsUsed++;
+        }
+        else
+        {
+            // see if the key already exists and update the value if it does
+            HASH_ENTRY* pHashEntry = pInternalHashTable->Buckets[nIndex];
+            while (pHashEntry)
+            {
+                if (pInternalHashTable->Buckets[nIndex]->nKeyLength == nKeyLength)
+                {
+                    if (memcmp(pInternalHashTable->Buckets[nIndex]->pKey, pKey, nKeyLength) == 0)
+                    {
+                        pInternalHashTable->Buckets[nIndex]->pValue = pValue;
+                        SetLastError(ERROR_SUCCESS);
+                        return TRUE;
+                    }
+                }
+
+                pHashEntry = pHashEntry->pNext;
+            }
+            
+            // create a new node in the linked list
+            PHASH_ENTRY pNewEntry = _CreateHashEntry(pKey, nKeyLength, pValue);
+            if (pNewEntry == NULL)
+                return FALSE;
+
+            pNewEntry->pNext = pInternalHashTable->Buckets[nIndex];
+            pInternalHashTable->Buckets[nIndex] = pNewEntry;
+        }
+    }
+    // memory for the bucket has not been allocated yet
+    else
+    {
+        PHASH_ENTRY pHashEntry = _CreateHashEntry(pKey, nKeyLength, pValue);
+        if (pHashEntry == NULL)
+            return FALSE;
+
+        pInternalHashTable->Buckets[nIndex] = pHashEntry;
+        pInternalHashTable->nNumberOfBucketsUsed++;
+    }
+
+    pInternalHashTable->nNumberOfEntries++;
+
+    // see if we need to resize the hash table
+    if ((pInternalHashTable->nNumberOfEntries / pInternalHashTable->dLoadFactor) > pInternalHashTable->nNumberOfBuckets)
+    {
+        _HashTableExpand(self);
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+}
+
+
+STATIC
+PVOID
+_GetValue(
+    struct _HASH_TABLE* self,
+    PVOID pKey,
+    SIZE_T nKeyLength)
+{
+    // _FindEntry sets the last error
+    PHASH_ENTRY pHashEntry = _FindEntry(self, pKey, nKeyLength);
+
+    if (pHashEntry != NULL)
+    {
+        return pHashEntry->pValue;
+    }
+
+    return NULL;
+}
+
+
+STATIC
+PHASH_ENTRY
+_FindEntry(
+    struct _HASH_TABLE* self,
+    PVOID pKey,
+    SIZE_T nKeyLength)
+{
+    DWORD dwHash = 0;
+    SIZE_T nIndex = 0;
+    
+    if (self == NULL
+        || nKeyLength == 0
+        || pKey == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return NULL;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = self->pInternal;
+
+    if (pInternalHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return NULL;
+    }
+
+    if (pInternalHashTable->nNumberOfBuckets == 0)
+    {
+        SetLastError(ERROR_NO_MATCH);
+        return NULL;
+    }
+
+    dwHash = _Fnv1aHash32(pKey, nKeyLength);
+    //printf("HASH: 0x%x\n", dwHash);
+    nIndex = dwHash % pInternalHashTable->nNumberOfBuckets;
+    
+    if (pInternalHashTable->Buckets[nIndex] == NULL)
+    {
+        SetLastError(ERROR_NO_MATCH);
+        return NULL;
+    }
+
+    // if there is nothing in the slot then nothing has been assigned
+    if (pInternalHashTable->Buckets[nIndex]->bIsFull == FALSE)
+    {
+        SetLastError(ERROR_NO_MATCH);
+        return NULL;
+    }
+
+    PHASH_ENTRY pHashEntry = pInternalHashTable->Buckets[nIndex];
+    // check every slot in the bucket
+    while (pHashEntry)
+    {
+        // if Key Lengths are different then the keys cant match
+        if (pHashEntry->nKeyLength == nKeyLength)
+        {
+            // check if keys match
+            if (memcmp(pHashEntry->pKey, pKey, nKeyLength) == 0)
+            {
+                SetLastError(ERROR_SUCCESS);
+                return pHashEntry;
+            }
+        }
+        pHashEntry = pHashEntry->pNext;
+    }
+
+    SetLastError(ERROR_NO_MATCH);
+    return NULL;
+}
+
+
+/*
+* Frees an entry in the hashtable
+*/
+STATIC
+BOOL
+_HashTableFreeEntry(
+    PHASH_ENTRY pHashEntry, 
+    BOOL bFreeKey, 
+    BOOL bFreeValue)
+{
+    if (pHashEntry == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    if (bFreeKey == TRUE)
+    {
+        HeapFree(GetProcessHeap(), 0, pHashEntry->pKey);
+        pHashEntry->pKey = NULL;
+    }
+
+    if (bFreeValue == TRUE)
+    {
+        HeapFree(GetProcessHeap(), 0, pHashEntry->pValue);
+        pHashEntry->pValue = NULL;
+    }
+
+    HeapFree(GetProcessHeap(), 0, pHashEntry);
+
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+}
+
+
+STATIC
+BOOL
+_HashTableFreeList(
+    PHASH_ENTRY pHashEntry, 
+    BOOL bFreeKey, 
+    BOOL bFreeValue)
+{
+    PHASH_ENTRY pTempHashEntry = NULL;
+    if (pHashEntry == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    // free every node in the list
+    while (pHashEntry)
+    {
+        pTempHashEntry = pHashEntry;
+        pHashEntry = pHashEntry->pNext;
+
+        _HashTableFreeEntry(pTempHashEntry, bFreeKey, bFreeValue);
+        pTempHashEntry = 0;
+    }
+
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+}
+
+
+BOOL
+FreeHashTable(
+    PHASH_TABLE *pHashTable, 
+    BOOL bFreeKey, 
+    BOOL bFreeValue)
+{
+    if (pHashTable == NULL || (*pHashTable) == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    if ((*pHashTable)->pInternal == NULL)
+    {
+        return FALSE;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = (*pHashTable)->pInternal;
+    
+    if (pInternalHashTable == NULL)
+    {
+        SetLastError(ERROR_INVALID_HANDLE);
+        return FALSE;
+    }
+
+    // iterate every bucket
+    for (size_t index = 0; index < pInternalHashTable->nNumberOfBuckets; index++)
+    {
+        // make sure we have somthing to work with
+        if ((pInternalHashTable->Buckets != NULL) && (pInternalHashTable->Buckets[index] != NULL))
+        {
+            _HashTableFreeList(pInternalHashTable->Buckets[index], bFreeKey, bFreeValue);
+        }
+    }
+
+    HeapFree(GetProcessHeap(), 0, (*pHashTable)->pInternal);
+    HeapFree(GetProcessHeap(), 0, (*pHashTable));
+    (*pHashTable) = NULL;
+
+    SetLastError(ERROR_SUCCESS);
+    return TRUE;
+
+}
+
+
+PHASH_TABLE
+CreateHashTable(
+    SIZE_T nNumberOfInitalBuckets, 
+    DOUBLE dLoadFactor)
+{
+    // do not use a load factor under 1%
+    if (dLoadFactor < .01)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return NULL;
+    }
+
+    // Allocate memory for the hash table
+    PHASH_TABLE pHashTable = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(HASH_TABLE));
+    if (pHashTable == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return NULL;
+    }
+
+    if (IsPrime(nNumberOfInitalBuckets) != TRUE)
+    {
+        nNumberOfInitalBuckets = FindClosestPrime(nNumberOfInitalBuckets);
+    }
+
+    // Allocate memory for the buckets
+    PHASH_ENTRY *pBuckets = HeapAlloc(GetProcessHeap(), 
+                                      HEAP_ZERO_MEMORY,
+                                      sizeof(HASH_ENTRY *) * nNumberOfInitalBuckets);
+
+    if (pBuckets == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        HeapFree(GetProcessHeap(), 0, pHashTable);
+        return NULL;
+    }
+
+    PINTERNAL_HASH_TABLE pInternalHashTable = HeapAlloc(GetProcessHeap(),
+                                              HEAP_ZERO_MEMORY,
+                                              sizeof(INTERNAL_HASH_TABLE));
+
+    if (pInternalHashTable == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        HeapFree(GetProcessHeap(), 0, pBuckets);
+        HeapFree(GetProcessHeap(), 0, pHashTable);
+        return NULL;
+    }
+    
+    pInternalHashTable->dLoadFactor = dLoadFactor;
+    pInternalHashTable->nNumberOfBuckets = nNumberOfInitalBuckets;
+    pInternalHashTable->Buckets = pBuckets;
+    pHashTable->pInternal = pInternalHashTable;
+    pHashTable->DeleteEntry = _DeleteEntry;
+    pHashTable->GetValue = _GetValue;
+    pHashTable->SetEntry = _SetEntry;
+    pHashTable->GetNumberOfEntries = _GetNumberOfEntries;
+    pHashTable->GetFirstEntry = (HANDLE)_HashTableGetFirstEntry;
+    pHashTable->GetNextEntry = (BOOL (*)(HANDLE , PHASH_ENTRY *))_HashTableGetNextEntry;
+
+    SetLastError(ERROR_SUCCESS);
+    return pHashTable;
+}

--- a/base/applications/network/netsh/hashtable.h
+++ b/base/applications/network/netsh/hashtable.h
@@ -1,0 +1,46 @@
+/*
+ * PROJECT:    Hash Table
+ * LICENSE:    MIT (https://spdx.org/licenses/MIT)
+ * PURPOSE:    Hash Table header file
+ * COPYRIGHT:  Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
+ */
+ 
+#include <windows.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+// todo make bIsFull private
+typedef struct _HASH_ENTRY
+{
+    void* pKey;
+    SIZE_T nKeyLength;
+    void* pValue;
+    BOOL bIsFull;
+
+    struct _HASH_ENTRY* pNext;
+}HASH_ENTRY, *PHASH_ENTRY;
+
+typedef struct _HASH_TABLE
+{
+    PVOID pInternal;
+    BOOL (*DeleteEntry)(struct _HASH_TABLE* self, PVOID pKey, SIZE_T nKeyLength, BOOL bFreeKey, BOOL bFreeValue);
+    BOOL (*SetEntry)(struct _HASH_TABLE** self, PVOID pKey, SIZE_T nKeyLength, PVOID pValue);
+    PVOID (*GetValue)(struct _HASH_TABLE* self, PVOID pKey, SIZE_T nKeyLength);
+    SIZE_T (*GetNumberOfEntries)(struct _HASH_TABLE* self);
+    HANDLE (*GetFirstEntry)(struct _HASH_TABLE* self, PHASH_ENTRY *pHashEntry);
+    BOOL (*GetNextEntry)(HANDLE hIterator, PHASH_ENTRY *pHashEntry);
+
+}HASH_TABLE, * PHASH_TABLE;
+
+BOOL
+FreeHashTable(
+    PHASH_TABLE* pHashTable,
+    BOOL bFreeKey,
+    BOOL bFreeValue);
+
+PHASH_TABLE
+CreateHashTable(
+    SIZE_T nNumberOfInitalSlots,
+    DOUBLE dLoadFactor);

--- a/base/applications/network/netsh/help.c
+++ b/base/applications/network/netsh/help.c
@@ -3,6 +3,7 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell builtin help command and support functions
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 /* INCLUDES *******************************************************************/
@@ -21,6 +22,7 @@ GetContextFullName(
     _Inout_ LPWSTR pszBuffer,
     _In_ DWORD cchLength)
 {
+    DPRINT("%s()\n", __FUNCTION__);
     if (pContext->pParentContext != NULL)
     {
         GetContextFullName(pContext->pParentContext, pszBuffer, cchLength);
@@ -34,65 +36,186 @@ GetContextFullName(
 }
 
 
-static
+/*
+Displays help for a context, by listing the available
+commands, groups, and sub-contexts available
+*/
 VOID
 HelpContext(
     PCONTEXT_ENTRY pContext)
 {
+    DPRINT("%s()\n", __FUNCTION__);
     PCONTEXT_ENTRY pSubContext;
     PCOMMAND_ENTRY pCommand;
     PCOMMAND_GROUP pGroup;
     WCHAR szBuffer[80];
-
-    if (pContext != pRootContext)
-        HelpContext(pContext->pParentContext);
-
-    if (pContext == pCurrentContext)
+    BOOL bDontSkip = TRUE;
+    PCONTEXT_ENTRY pRootContext = GetRootContext();
+    STACK *pContextStack = NULL;
+    
+    pContextStack = CreateStack();
+    
+    if (pContextStack == NULL)
     {
-        ConPrintf(StdOut, L"\nCommands in this context:\n");
+        DPRINT1("%s Cannot create stack\n", __FUNCTION__);
+        return;
     }
-    else if (pContext == pRootContext)
+    
+    // Backtrack to root node
+    do
     {
-        ConPrintf(StdOut, L"\nCommands in the netsh-context:\n");
-    }
-    else
-    {
-        GetContextFullName(pContext, szBuffer, 80);
-        ConPrintf(StdOut, L"\nCommands in the %s-context:\n", szBuffer);
-    }
+        StackPush(pContextStack, pContext);
+        pContext = pContext->pParentContext;
+    }while (pContext);
+    
+    // process the contexts    
+    while (!IsStackEmpty(pContextStack))
+    {   
+        pContext = StackPop(pContextStack);
+        if (pContext == NULL)
+        {
+            StackFree(pContextStack, FALSE);
+            return;
+        }
+                
+        if (pContext == GetCurrentContext())
+        {
+            ConPrintf(StdOut, L"\nCommands in this context:\n");
+        }
+        
+        else if (pContext == pRootContext)
+        {
+            ConPrintf(StdOut, L"\nCommands in the netsh-context:\n");
+        }
+        else
+        {
+            GetContextFullName(pContext, szBuffer, 80);
+            ConPrintf(StdOut, L"\nCommands in the %s context:\n", szBuffer);
+        }
 
-    pCommand = pContext->pCommandListHead;
-    while (pCommand != NULL)
-    {
-        if (LoadStringW(pContext->hModule, pCommand->dwShortCmdHelpToken, szBuffer, 80) == 0)
-            szBuffer[0] = UNICODE_NULL;
-        ConPrintf(StdOut, L"%-15s - %s\n", pCommand->pwszCmdToken, szBuffer);
-        pCommand = pCommand->pNext;
-    }
+        // process commands 
+        pCommand = pContext->pCommandListHead;
+        while (pCommand != NULL)
+        {
+            if (pCommand->pOsVersionCheck != NULL)
+            {
+                DPRINT1("%s CallOsVersionCheck(pCommand->pOsVersionCheck\n", __FUNCTION__);
+                bDontSkip  = CallOsVersionCheck(pCommand->pOsVersionCheck);
+            }
+            else
+            {
+                bDontSkip = TRUE;
+            }
+      
+            if(bDontSkip)
+            {
+                if (LoadStringW(pCommand->hModule, pCommand->dwShortCmdHelpToken, szBuffer, 80) == 0)
+                    szBuffer[0] = UNICODE_NULL;
+                ConPrintf(StdOut, L"%-15s - %s", pCommand->pwszCmdToken, szBuffer);
+            }
+        
+            pCommand = pCommand->pNext;
+        }
 
-    pGroup = pContext->pGroupListHead;
-    while (pGroup != NULL)
-    {
-        if (LoadStringW(pContext->hModule, pGroup->dwShortCmdHelpToken, szBuffer, 80) == 0)
-            szBuffer[0] = UNICODE_NULL;
-        ConPrintf(StdOut, L"%-15s - %s\n", pGroup->pwszCmdGroupToken, szBuffer);
-        pGroup = pGroup->pNext;
+        // process groups
+        pGroup = pContext->pGroupListHead;
+        while (pGroup != NULL)
+        {
+            if (pGroup->pOsVersionCheck != NULL)
+            {
+                DPRINT1("%s CallOsVersionCheck(pGroup->pOsVersionCheck)\n", __FUNCTION__);
+                bDontSkip = CallOsVersionCheck(pGroup->pOsVersionCheck);
+            }
+            else
+            {
+                bDontSkip = TRUE;
+            }
+      
+            if (bDontSkip)
+            {
+                if (LoadStringW(pGroup->hModule, pGroup->dwShortCmdHelpToken, szBuffer, 80) == 0)
+                    szBuffer[0] = UNICODE_NULL;
+                ConPrintf(StdOut, L"%-15s - %s", pGroup->pwszCmdGroupToken, szBuffer);
+            }
+        
+            pGroup = pGroup->pNext;
+    
+        }
+        DPRINT1("%s pSubContext = pContext->pSubContextHead;\n", __FUNCTION__);
+        pSubContext = pContext->pSubContextHead;
+        while (pSubContext != NULL)
+        {
+            DPRINT1("%s In while (pSubContext != NULL) loop\n", __FUNCTION__);
+            GetContextFullName(pSubContext, szBuffer, 80);
+            ConPrintf(StdOut, L"%-15s - Changes to the \"%s\" context.\n", pSubContext->pszContextName, szBuffer);
+            pSubContext = pSubContext->pNext;
+        }
     }
-
+    
+    StackFree(pContextStack, FALSE);
+    
     pSubContext = pContext->pSubContextHead;
-    while (pSubContext != NULL)
+    
+    if (pSubContext != NULL)
     {
+        // TODO localize
         GetContextFullName(pSubContext, szBuffer, 80);
-        ConPrintf(StdOut, L"%-15s - Changes to the \"%s\" context.\n", pSubContext->pszContextName, szBuffer);
-        pSubContext = pSubContext->pNext;
+        ConPrintf(StdOut, L"\nThe following sub-contexts are available:\n");
+        
+        while (pSubContext != NULL)
+        {
+            ConPrintf(StdOut, L" %s", pSubContext->pszContextName, szBuffer);
+            pSubContext = pSubContext->pNext;
+        }
+        
+        ConPrintf(StdOut, L"\n");
     }
+    
+    // TODO localize
+    ConPrintf(StdOut, L"\nTo view help for a command, type the command, followed by a space, and then\n type ?.\n\n");
+    
 }
 
-
+// shows help for a command group
 VOID
 HelpGroup(
     PCOMMAND_GROUP pGroup)
 {
+    DPRINT("%s()\n", __FUNCTION__);
+    PCOMMAND_ENTRY pCommand;
+    WCHAR szBuffer[1024]; // todo allocate dynamically
+
+    ConResPrintf(StdOut, IDS_HELP_HEADER);
+    ConPrintf(StdOut, L"\nCommands in this context:\n");
+
+    pCommand = pGroup->pCommandListHead;
+    
+    if(pCommand == NULL)
+        ConPuts(StdOut, L"\n");
+    
+    // Follow the linked list until we run out of nodes    
+    while (pCommand != NULL)
+    {
+        // Create a temporary array that holds a concatenated string containing  pGroup->pwszCmdGroupToken, pCommand->pwszCmdToken
+        // for every entry, once thats done sort the array in lexicographical order
+        // display the results
+        swprintf(szBuffer, L"%s %s", pGroup->pwszCmdGroupToken, pCommand->pwszCmdToken);
+        ConPrintf(StdOut, L"%-15s - ", szBuffer);
+        PrintMessageFromModule(pGroup->hModule, pCommand->dwShortCmdHelpToken);
+        pCommand = pCommand->pNext;
+    }
+    
+}
+
+/*
+
+
+// shows help for a command group
+VOID
+HelpGroup(
+    PCOMMAND_GROUP pGroup)
+{
+    DPRINT("%s()\n", __FUNCTION__);
     PCOMMAND_ENTRY pCommand;
     WCHAR szBuffer[64];
 
@@ -101,16 +224,27 @@ HelpGroup(
     ConPrintf(StdOut, L"\nCommands in this context:\n");
 
     pCommand = pGroup->pCommandListHead;
+    
+    if(pCommand == NULL)
+        ConPuts(StdOut, L"\n");
+    
+    // Follow the linked list until we run out of nodes    
     while (pCommand != NULL)
     {
         swprintf(szBuffer, L"%s %s", pGroup->pwszCmdGroupToken, pCommand->pwszCmdToken);
         ConPrintf(StdOut, L"%-15s - ", szBuffer);
-        ConResPuts(StdOut, pCommand->dwShortCmdHelpToken);
+        PrintMessageFromModule(pGroup->hModule, pCommand->dwShortCmdHelpToken);
         pCommand = pCommand->pNext;
     }
+    
 }
 
 
+
+
+
+
+*/
 DWORD
 WINAPI
 HelpCommand(
@@ -122,11 +256,12 @@ HelpCommand(
     LPCVOID pvData,
     BOOL *pbDone)
 {
+    DPRINT("%s()\n", __FUNCTION__);
     PCONTEXT_ENTRY pContext;
 
     ConResPrintf(StdOut, IDS_HELP_HEADER);
 
-    pContext = pCurrentContext;
+    pContext = GetCurrentContext();
     if (pContext == NULL)
     {
         DPRINT1("HelpCommand: invalid context %p\n", pContext);
@@ -135,10 +270,10 @@ HelpCommand(
 
     HelpContext(pContext);
 
-    if (pCurrentContext->pSubContextHead != NULL)
+    if (GetCurrentContext()->pSubContextHead != NULL)
     {
         ConResPrintf(StdOut, IDS_SUBCONTEXT_HEADER);
-        pContext = pCurrentContext->pSubContextHead;
+        pContext = GetCurrentContext()->pSubContextHead;
         while (pContext != NULL)
         {
             ConPrintf(StdOut, L" %s", pContext->pszContextName);

--- a/base/applications/network/netsh/interpreter.c
+++ b/base/applications/network/netsh/interpreter.c
@@ -3,144 +3,676 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell command interpreter
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
-/* INCLUDES *******************************************************************/
+/* DEFINES *******************************************************************/
 
 #include "precomp.h"
 
 #define NDEBUG
 #include <debug.h>
 
+#define HASH_TABLE_INITIAL_SLOT_SIZE 101
+#define HASH_TABLE_LOAD_FACTOR 0.50
+
+enum INTERPRET_EVENT
+{
+    INTERPRET_EVENT_SEARCH_FOR_TOKENS,
+    INTERPRET_EVENT_GROUP,
+    INTERPRET_EVENT_CONTEXT,
+    INTERPRET_EVENT_COMMAND,
+    INTERPRET_EVENT_SWITCH_TO_PARENT,
+    INTERPRET_EVENT_NOTHING_FOUND,
+    INTERPRET_EVENT_FINISHED
+};
+
+static PHASH_TABLE g_pHashTable = NULL;
+
+
 /* FUNCTIONS *****************************************************************/
 
+static
+BOOL
+CreateAliasTable()
+{
+    DOUBLE dLoadFactor = HASH_TABLE_LOAD_FACTOR;
+    SIZE_T nNumberOfInitalSlots = HASH_TABLE_INITIAL_SLOT_SIZE;
+    g_pHashTable = CreateHashTable(nNumberOfInitalSlots, dLoadFactor);
+    
+    if (g_pHashTable == NULL)
+    {
+        return FALSE;
+    }
+    
+    return TRUE;
+}
+
+
+static
+BOOL
+DeleteAliasTable()
+{
+    if (g_pHashTable != NULL)
+        return FreeHashTable(&g_pHashTable, TRUE, TRUE);
+    else
+        return TRUE;
+}
+
+
+VOID
+DisplayAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength)
+{
+    if (g_pHashTable == NULL)
+    {
+        // todo localize
+        ConPrintf(StdOut, L"The following alias was not found: %ls.\n\n", (PWSTR)pKey);
+        return;
+    }
+        
+    LPCWSTR pwszValue = (LPCWSTR)g_pHashTable->GetValue(g_pHashTable, pKey, nKeyLength);
+    
+    if (pwszValue != NULL)
+        ConPrintf(StdOut, L"%ls\n\n", pwszValue);
+    else
+        // todo localize
+        ConPrintf(StdOut, L"The following alias was not found: %ls.\n\n", (PWSTR)pKey);
+}
+
+
+VOID
+DisplayAliasTable()
+{
+    if (g_pHashTable == NULL)
+    {
+        ConPrintf(StdOut, L"\n");
+        return;
+    }
+        
+    PHASH_ENTRY pHashEntry = NULL;
+    HANDLE hIterator = g_pHashTable->GetFirstEntry(g_pHashTable, &pHashEntry);
+
+    // print all of the entries and their values
+    while (pHashEntry)
+    {
+        ConPrintf(StdOut, L"%ls %ls\n", (wchar_t*)pHashEntry->pKey, (wchar_t *)pHashEntry->pValue);
+        g_pHashTable->GetNextEntry(&hIterator, &pHashEntry);
+    }
+    
+    ConPrintf(StdOut, L"\n");
+}
+
+
+BOOL
+SetAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength, 
+    PVOID pValue)
+{
+    if (g_pHashTable == NULL)
+    {
+        if (CreateAliasTable() == FALSE)
+            return FALSE;
+    }
+    
+    if (g_pHashTable->SetEntry(&g_pHashTable, pKey, nKeyLength, pValue) == FALSE)
+    {
+        // todo investigate how netsh reports keys that can't be added
+        return FALSE;
+    }
+    
+    return TRUE;
+}
+
+
+BOOL
+DeleteAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength)
+{
+    if (g_pHashTable == NULL)
+    {
+        return FALSE;
+    }
+
+    // see if the entry was deleted
+    if (g_pHashTable->DeleteEntry(g_pHashTable, pKey, nKeyLength, FALSE, FALSE) == FALSE)
+    {
+        return FALSE;
+    }
+
+    // if the table is empty delete it and free memory
+    if (g_pHashTable->GetNumberOfEntries(g_pHashTable) == 0)
+    {
+        DeleteAliasTable();
+    }
+    
+    return TRUE;
+}
+
+
+/*
+TODO When WMI is implemented this function will have to be updated to utilize WMI
+to supply the arguments for the OsVersionCheck call back function.
+*/
+BOOL
+CallOsVersionCheck(PNS_OSVERSIONCHECK NsOsversioncheck)
+{
+  UINT CIMOSType = 0;
+  UINT CIMOSProductSuite = 0;
+  LPCWSTR CIMOSVersion = L"0.0.0";
+  LPCWSTR CIMOSBuildNumber = L"00000";
+  LPCWSTR CIMServicePackMajorVersion = L"0";
+  LPCWSTR CIMServicePackMinorVersion = L"0";
+  UINT uiReserved = 0;
+  DWORD dwReserved = 0;
+
+DPRINT("%s()\n", __FUNCTION__);
+if (NsOsversioncheck != NULL)
+{
+    return NsOsversioncheck(CIMOSType,
+                            CIMOSProductSuite,
+                            CIMOSVersion,
+                            CIMOSBuildNumber,
+                            CIMServicePackMajorVersion,
+                            CIMServicePackMinorVersion,
+                            uiReserved,
+                            dwReserved);
+}
+
+return TRUE;                    
+}
+
+
+/*
+Searches a linked list for a node that has a member 
+named pwszCmdToken for a string that starts with 
+pwszCmdToken and returns a pointer to the node if 
+found, otherwise return NULL. Ideally pCommandListHead 
+should point to the head of a command list.
+*/
+static
+PCOMMAND_ENTRY
+_SearchCommand(
+    LPCWSTR pwszCmdToken,
+    PCOMMAND_ENTRY pCommandListHead)
+{
+    DPRINT1("%s \n", __FUNCTION__);
+    PCOMMAND_ENTRY pCurrentCommand = pCommandListHead;
+    
+    if (pwszCmdToken == NULL)
+        {
+            DPRINT1("%s pwszCmdToken == NULL\n", __FUNCTION__);
+            return NULL;
+        }
+    // search through the linked list and try to find a node
+    // where the pwszCmdToken string is contained        
+    while(pCurrentCommand)
+    {
+        // if true we have found are matched, so we can exit
+        if (MatchToken(pwszCmdToken, pCurrentCommand->pwszCmdToken))
+        {
+            DPRINT1("%s pCurrentCommand->pwszCmdToken: %ls\n", __FUNCTION__, pCurrentCommand->pwszCmdToken);
+            return pCurrentCommand;
+        }
+            
+        // goto the next node in the list    
+        pCurrentCommand = pCurrentCommand->pNext;
+    }
+    
+    DPRINT1("%s returning NULL\n", __FUNCTION__);
+    return NULL;
+}
+
+
+static
+PCOMMAND_GROUP
+_SearchGroup(
+    LPCWSTR pwszCmdGroupToken,
+    PCOMMAND_GROUP pGroupListHead)
+{
+    DPRINT1("%s \n", __FUNCTION__);
+    PCOMMAND_GROUP pCurrentGroup = pGroupListHead;
+    
+    if (pwszCmdGroupToken == NULL)
+        {
+            DPRINT1("%s pwszCmdGroupToken == NULL\n", __FUNCTION__);
+            return NULL;
+        }
+            
+    while(pCurrentGroup)
+    {
+        if (MatchToken(pwszCmdGroupToken, pCurrentGroup->pwszCmdGroupToken))
+        {
+            DPRINT1("%s pCurrentGroup->pwszCmdGroupToken: %ls\n", __FUNCTION__, pCurrentGroup->pwszCmdGroupToken);
+            return pCurrentGroup;
+        }
+        pCurrentGroup = pCurrentGroup->pNext;
+    }
+    
+    DPRINT1("%s returning NULL\n", __FUNCTION__);
+    return NULL;
+}
+
+
+static
+PCONTEXT_ENTRY
+_SearchSubContext(
+    PWSTR pszContextName,
+    PCONTEXT_ENTRY pContextHead)
+{
+
+    if (pszContextName == NULL)
+    {
+        DPRINT1("%s pszContextName == NULL\n", __FUNCTION__);
+        return NULL;
+    }
+        
+    PCONTEXT_ENTRY pCurrentContext = NULL;
+    
+    if (pContextHead)
+    {
+        DPRINT1("%s pSubContextHead\n", __FUNCTION__);
+        pCurrentContext = pContextHead->pSubContextHead;
+    }
+    
+    while(pCurrentContext)
+    {
+        if (MatchToken(pszContextName, pCurrentContext->pszContextName))
+        {
+            DPRINT1("%s pCurrentContext->pszContextName: %ls\n", __FUNCTION__, pCurrentContext->pszContextName);
+            return pCurrentContext;
+        }
+        
+        pCurrentContext = pCurrentContext->pNext;
+    }
+    
+    DPRINT1("%s returning NULL\n", __FUNCTION__);
+    return NULL;
+}
+
+
+/*
+* TODO need to refactor, move code in switch cases to their
+* own functions.
+*/
 BOOL
 InterpretCommand(
     _In_ LPWSTR *argv,
     _In_ DWORD dwArgCount)
 {
-    PCONTEXT_ENTRY pContext, pSubContext;
-    PCOMMAND_ENTRY pCommand;
-    PCOMMAND_GROUP pGroup;
+    /************* Declerations *******************************/
+    BOOL bIsHelpRequest = FALSE;
+    PCONTEXT_ENTRY pContext = NULL;
+    PCONTEXT_ENTRY pCurrentContext = NULL;
+    PCOMMAND_GROUP pGroup = NULL;
+    PCOMMAND_GROUP pCurrentGroup = NULL;
+    PCOMMAND_ENTRY pCommand = NULL;
+    PCOMMAND_ENTRY pCurrentCommand = NULL;
+    PLIST pVisitedContextList;
+    BOOL bIsInteractiveMode = TRUE;
+    BOOL bIsOffline = !GetMode();
+    BOOL bInherited = FALSE;
+    enum INTERPRET_EVENT event;
+    DWORD dwArgIndex = 0;
     BOOL bDone = FALSE;
-    DWORD dwHelpLevel = 0;
     DWORD dwError = ERROR_SUCCESS;
-
-    /* If no args provided */
-    if (dwArgCount == 0)
+    PCONTEXT_ENTRY pRootContext = GetRootContext();
+    /**********************************************************/
+    
+    /**************** Check input argumemts *******************/
+    if (argv == NULL)
+    {
+        DPRINT1("%s argv == NULL\n", __FUNCTION__);
         return TRUE;
-
-    if (pCurrentContext == NULL)
-    {
-        DPRINT1("InterpretCmd: invalid context %p\n", pCurrentContext);
-        return FALSE;
     }
-
-    if ((_wcsicmp(argv[dwArgCount - 1], L"?") == 0) ||
-        (_wcsicmp(argv[dwArgCount - 1], L"help") == 0))
+        
+    if (dwArgCount == 0)
     {
-        dwHelpLevel = dwArgCount - 1;
+        DPRINT1("%s dwArgCount == 0\n", __FUNCTION__);
+        return TRUE;
     }
-
-    pContext = pCurrentContext;
-
-    while (TRUE)
+    
+    if (GetCurrentContext() == NULL)
     {
-        pCommand = pContext->pCommandListHead;
-        while (pCommand != NULL)
+        DPRINT1("%s GetCurrentContext IS Null\n", __FUNCTION__);
+        SetCurrentContext(pRootContext);  
+    }
+    /**********************************************************/
+    
+    
+    // ********************************************************************************************    
+    //                                Check for comment
+    // ********************************************************************************************
+    if (_wcsicmp(argv[0], L"#") == 0)
+    {
+        return TRUE;
+    }
+    // ********************************************************************************************
+    
+    // ********************************************************************************************    
+    //                                Check for help token
+    // ********************************************************************************************
+    bIsHelpRequest = ((_wcsicmp(argv[0], L"?") == 0) && (dwArgCount == 1));
+    bIsHelpRequest |= ((_wcsicmp(argv[0], L"help") == 0) && (dwArgCount == 1));
+    
+    if (bIsHelpRequest)
+    {   
+        HelpContext(GetCurrentContext());
+        return TRUE;
+    }
+    
+    
+    pVisitedContextList = CreateList();
+    if (pVisitedContextList == NULL)
+    {
+        DPRINT1("%s pVisitedContextList is NULL!\n", __FUNCTION__);
+        return TRUE;
+    }
+    
+    pCurrentContext = GetCurrentContext();
+    pCurrentGroup = pCurrentContext->pGroupListHead;
+    pCurrentCommand = pCurrentContext->pCommandListHead;
+                    
+    event = INTERPRET_EVENT_SEARCH_FOR_TOKENS;
+    
+    while(dwArgIndex < dwArgCount)
+    {                                   
+        switch(event)
         {
-            if (_wcsicmp(argv[0], pCommand->pwszCmdToken) == 0)
-            {
-                if (dwHelpLevel == 1)
+            case INTERPRET_EVENT_SEARCH_FOR_TOKENS:
+                DPRINT1("%s INTERPRET_EVENT_SEARCH_FOR_TOKENS\n", __FUNCTION__);
+                    
+                pCommand = _SearchCommand(argv[dwArgIndex], pCurrentCommand);
+                if (pCommand != NULL)
                 {
-                    ConResPrintf(StdOut, pCommand->dwCmdHlpToken);
-                    return TRUE;
+                    event = INTERPRET_EVENT_COMMAND;
+                    break;
                 }
-                else
+                
+                pGroup = _SearchGroup(argv[dwArgIndex], pCurrentGroup);
+                if (pGroup != NULL)
                 {
-                    dwError = pCommand->pfnCmdHandler(NULL, argv, 0, dwArgCount, 0, NULL, &bDone);
-                    if (dwError != ERROR_SUCCESS)
+                    event = INTERPRET_EVENT_GROUP;
+                    break;
+                }
+                
+                pContext = _SearchSubContext(argv[dwArgIndex], pCurrentContext);
+                if (pContext != NULL)
+                {
+                    event = INTERPRET_EVENT_CONTEXT;
+                    break;
+                }
+                
+
+                DPRINT1("%s Checking if context was already visited\n", __FUNCTION__);
+                for (PLIST_NODE tNode = pVisitedContextList->Head; tNode; tNode = tNode->Next)
+                {
+                    DPRINT1("%s Comparing pointers\n", __FUNCTION__);
+                    if ((PCONTEXT_ENTRY)tNode->Data == pCurrentContext)
                     {
-                        ConPrintf(StdOut, L"Error: %lu\n\n");
-                        ConResPrintf(StdOut, pCommand->dwCmdHlpToken);
-                    }
-                    return !bDone;
-                }
-            }
-
-            pCommand = pCommand->pNext;
-        }
-
-        pGroup = pContext->pGroupListHead;
-        while (pGroup != NULL)
-        {
-            if (_wcsicmp(argv[0], pGroup->pwszCmdGroupToken) == 0)
-            {
-                if (dwHelpLevel == 1)
-                {
-                    HelpGroup(pGroup);
-                    return TRUE;
-                }
-
-                pCommand = pGroup->pCommandListHead;
-                while (pCommand != NULL)
-                {
-                    if ((dwArgCount > 1) && (_wcsicmp(argv[1], pCommand->pwszCmdToken) == 0))
-                    {
-                        if (dwHelpLevel == 2)
-                        {
-                            ConResPrintf(StdOut, pCommand->dwCmdHlpToken);
-                            return TRUE;
-                        }
+                        DPRINT1("%s Context already visited\n", __FUNCTION__);
+                        if (pCurrentContext->pParentContext && pCurrentContext->pParentContext->pParentContext)
+                            pCurrentContext = pCurrentContext->pParentContext->pParentContext;
                         else
                         {
-                            dwError = pCommand->pfnCmdHandler(NULL, argv, 1, dwArgCount, 0, NULL, &bDone);
-                            if (dwError != ERROR_SUCCESS)
-                            {
-                                ConPrintf(StdOut, L"Error: %lu\n\n");
-                                ConResPrintf(StdOut, pCommand->dwCmdHlpToken);
-                                return TRUE;
-                            }
-                            return !bDone;
+                            DPRINT1("%s Parent or grandparent is NULL\n", __FUNCTION__);
+                            event = INTERPRET_EVENT_NOTHING_FOUND;
+                            goto finish_token_search;
                         }
                     }
-
-                    pCommand = pCommand->pNext;
                 }
-
-                HelpGroup(pGroup);
-                return TRUE;
-            }
-
-            pGroup = pGroup->pNext;
-        }
-
-        if (pContext == pCurrentContext)
-        {
-            pSubContext = pContext->pSubContextHead;
-            while (pSubContext != NULL)
-            {
-                if (_wcsicmp(argv[0], pSubContext->pszContextName) == 0)
+                
+                pVisitedContextList->Add(pVisitedContextList, pCurrentContext);
+                   
+                // nothing was found
+                event = INTERPRET_EVENT_SWITCH_TO_PARENT;
+                finish_token_search:
+                break;
+                
+            case INTERPRET_EVENT_COMMAND:
+                DPRINT1("%s INTERPRET_EVENT_COMMAND\n", __FUNCTION__);
+                
+                if (pCommand->pOsVersionCheck != NULL)
                 {
-                    pCurrentContext = pSubContext;
-                    return TRUE;
+                    if (!CallOsVersionCheck(pCommand->pOsVersionCheck))
+                    {
+                        event = INTERPRET_EVENT_NOTHING_FOUND;
+                        break;
+                    }
+                }
+                
+
+                if ((bInherited == TRUE) && (pCurrentContext != GetCurrentContext()) && 
+                    ((pCommand->dwFlags & CMD_FLAG_PRIVATE) == CMD_FLAG_PRIVATE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                
+                if (bIsInteractiveMode && ((pCommand->dwFlags & CMD_FLAG_INTERACTIVE) == CMD_FLAG_INTERACTIVE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                
+                if (bIsOffline && ((pCommand->dwFlags & CMD_FLAG_ONLINE) == CMD_FLAG_ONLINE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                // help requests for commands must have either the ? or help token immediately
+                // after the command, it must also be the last element of argv
+                bIsHelpRequest = FALSE;
+                if ((dwArgIndex + 1) <= (dwArgCount - 1))
+                {
+                    bIsHelpRequest = ((_wcsicmp(argv[dwArgIndex + 1], L"?") == 0) && (dwArgIndex + 1 == (dwArgCount - 1)));
+                    bIsHelpRequest |= ((_wcsicmp(argv[dwArgIndex + 1], L"help") == 0) && (dwArgIndex + 1 == (dwArgCount - 1)));
                 }
 
-                pSubContext = pSubContext->pNext;
-            }
-        }
+                if (bIsHelpRequest)
+                {
+                    DPRINT1("%s PrintMessageFromModule help request\n", __FUNCTION__);   
+                    PrintMessageFromModule(pCurrentContext->hModule, pCommand->dwCmdHlpToken);  
+                    event = INTERPRET_EVENT_FINISHED;
+                    break;
+                }
+                
+                if (pCommand->pfnCmdHandler != NULL)
+                {
+                    DPRINT("%s Calling pfnCmdHandler\n", __FUNCTION__);
+                    dwArgIndex++;
+                    dwError = pCommand->pfnCmdHandler(NULL, argv, dwArgIndex, dwArgCount, 0, NULL, &bDone);
+                    SetLastError(dwError);
+                    return !bDone;
+                }
+                    
+                event = INTERPRET_EVENT_FINISHED;
+                break;
+                
+            case INTERPRET_EVENT_GROUP:
+                DPRINT1("%s INTERPRET_EVENT_GROUP\n", __FUNCTION__);
 
-        if (pContext == pRootContext)
-            break;
-
-        pContext = pContext->pParentContext;
-    }
-
-    ConResPrintf(StdErr, IDS_INVALID_COMMAND, argv[0]);
-
-    return TRUE;
-}
-
+                if (pGroup->pOsVersionCheck != NULL)
+                {
+                    if (!CallOsVersionCheck(pGroup->pOsVersionCheck))
+                    {
+                        DPRINT1("%s !CallOsVersionCheck(pGroup->pOsVersionCheck) is TRUE\n", __FUNCTION__);
+                        event = INTERPRET_EVENT_NOTHING_FOUND;
+                        break;
+                    }
+                }
+                
+                if ((bInherited == TRUE) && (pCurrentContext != GetCurrentContext()) && 
+                    ((pGroup->dwFlags & CMD_FLAG_PRIVATE) == CMD_FLAG_PRIVATE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                
+                if (bIsInteractiveMode && ((pGroup->dwFlags & CMD_FLAG_INTERACTIVE) == CMD_FLAG_INTERACTIVE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                
+                if (bIsOffline && ((pGroup->dwFlags & CMD_FLAG_ONLINE) == CMD_FLAG_ONLINE))
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                // help requests for groups must have either the ? or help token immediately
+                // after the group
+                bIsHelpRequest = FALSE;
+                if ((dwArgIndex + 1) <= (dwArgCount - 1))
+                {
+                    bIsHelpRequest = (_wcsicmp(argv[dwArgIndex + 1], L"?") == 0);
+                    bIsHelpRequest |= (_wcsicmp(argv[dwArgIndex + 1], L"help") == 0);
+                }
+                
+                // if argv ends with a group token show help for that group
+                if (dwArgIndex == (dwArgCount - 1))
+                    bIsHelpRequest = TRUE;
+                
+                    
+                if (bIsHelpRequest)
+                {   
+                    HelpGroup(pGroup);
+                    event = INTERPRET_EVENT_FINISHED;
+                    break;
+                }
+                
+                dwArgIndex++;
+                pCurrentGroup = pGroup;
+                pCurrentCommand = pCurrentGroup->pCommandListHead;
+                
+                pCommand = _SearchCommand(argv[dwArgIndex], pCurrentCommand);
+                if (pCommand != NULL)
+                {
+                    event = INTERPRET_EVENT_COMMAND;
+                    break;
+                }
+                
+                event = INTERPRET_EVENT_NOTHING_FOUND;
+                break; 
+                               
+            case INTERPRET_EVENT_CONTEXT:
+                DPRINT1("%s INTERPRET_EVENT_CONTEXT\n", __FUNCTION__);
+                
+                
+                if (pContext != GetCurrentContext())
+                {
+                    DPRINT1("%s dwArgIndex: %lu, dwArgCount - 1: %lu\n", __FUNCTION__, 
+                                                                             dwArgIndex, 
+                                                                            (dwArgCount - 1));
+            
+                    // check to see if the context is the last token
+                    // if so switch to that context
+                    if (dwArgIndex == (dwArgCount - 1))
+                    {
+                        DPRINT1("%s Switching context\n", __FUNCTION__);
+                        SetCurrentContext(pContext);
+                        event = INTERPRET_EVENT_FINISHED;
+                        break;
+                    }
+                    
+                    // help requests for contexts must have either the ? or help token immediately
+                    // after the context
+                    bIsHelpRequest = FALSE;
+                    if ((dwArgIndex + 1) <= (dwArgCount - 1))
+                    {
+                        bIsHelpRequest = (_wcsicmp(argv[dwArgIndex + 1], L"?") == 0);
+                        bIsHelpRequest |= (_wcsicmp(argv[dwArgIndex + 1], L"help") == 0);
+                    }
+                
+                
+                    if (bIsHelpRequest)
+                    {   
+                        HelpContext(pContext);
+                        event = INTERPRET_EVENT_FINISHED;
+                        break;
+                    }
+                    
+                    // change the local context and update
+                    // the current command and group lists    
+                    DPRINT1("%s Found a context\n", __FUNCTION__);
+                    pCurrentContext = pContext;
+                    pCurrentGroup = pCurrentContext->pGroupListHead;
+                    pCurrentCommand = pCurrentContext->pCommandListHead;
+                    
+                    event = INTERPRET_EVENT_SEARCH_FOR_TOKENS;
+                    dwArgIndex++;
+                    break;
+                }
+                
+                // if we are here we are refering to ourselves
+                if (dwArgIndex == (dwArgCount - 1))
+                {
+                    event = INTERPRET_EVENT_FINISHED;
+                }
+                // netsh does not allow us to call commamds by refering to ourselves
+                else
+                {
+                    event = INTERPRET_EVENT_NOTHING_FOUND;
+                }
+                    
+                break;
+                
+            case INTERPRET_EVENT_SWITCH_TO_PARENT:
+                DPRINT1("%s INTERPRET_EVENT_SWITCH_TO_PARENT\n", __FUNCTION__);
+                
+                if (pCurrentContext->pParentContext == NULL)
+                {
+                    event =  INTERPRET_EVENT_NOTHING_FOUND;
+                    break;
+                }
+                
+                bInherited = TRUE;
+                pCurrentContext = pCurrentContext->pParentContext;
+                pCurrentGroup = pCurrentContext->pGroupListHead;
+                pCurrentCommand = pCurrentContext->pCommandListHead;
+                event = INTERPRET_EVENT_SEARCH_FOR_TOKENS;
+                dwArgIndex = 0;
+                break;
+                
+            case INTERPRET_EVENT_NOTHING_FOUND:
+                DPRINT1("%s INTERPRET_EVENT_NOTHING_FOUND\n", __FUNCTION__);
+                DPRINT1("%s Context, group, or command not found\n", __FUNCTION__);
+                SetLastError(dwError);
+    
+                LPWSTR lpwszLine = JoinStringsW(argv, dwArgCount, L" ");
+                if (lpwszLine != NULL)
+                    ConResPrintf(StdErr, IDS_INVALID_COMMAND, lpwszLine);    
+                else
+                    ConResPrintf(StdErr, IDS_INVALID_COMMAND, L""); 
+    
+                ConPrintf(StdErr, L"\n");
+                
+                pVisitedContextList->Free(pVisitedContextList);
+                return TRUE;
+                break;
+                
+            case INTERPRET_EVENT_FINISHED:
+                DPRINT1("%s INTERPRET_EVENT_FINISHED\n", __FUNCTION__);
+                pVisitedContextList->Free(pVisitedContextList);
+                return TRUE;
+                break;
+        } // end switch
+    } // end while   
+    
+    // we should not get here
+    pVisitedContextList->Free(pVisitedContextList);
+    return TRUE; 
+} 
+ 
 
 /*
  * InterpretScript(char *line):
@@ -184,6 +716,91 @@ InterpretScript(
 }
 
 
+static
+LPWSTR
+CreatePromptStringFromContext(
+    PCONTEXT_ENTRY pContext)
+{
+    size_t nPromptLength = 0;
+    STACK *pStack = NULL;
+    LPWSTR pwszPrompt = NULL;
+    pStack = CreateStack();
+    PCONTEXT_ENTRY pTempContext = NULL;
+    
+    if(pStack == NULL)
+        return NULL;
+    // todo add machine name with following format to prompt string
+    // [machine_name] netsh context>
+     
+    // start from the current node and work backwards to root node
+    // calculating the size needed for the promt string
+    while(pContext)
+    {
+        nPromptLength += wcslen(pContext->pszContextName) + (1 * sizeof(WCHAR)); // + 1 for an extra space
+        StackPush(pStack, pContext);
+ 
+        // climb the tree
+        pContext = pContext->pParentContext;
+    }
+    
+    nPromptLength += (1 * sizeof(WCHAR)); // to account for "\0"
+    pwszPrompt = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, nPromptLength * sizeof(WCHAR));
+    
+    // copy the context names to the prompt string
+    while(!IsStackEmpty(pStack))
+    {
+       pTempContext = StackPop(pStack);
+       if (pTempContext)
+       {
+           wcscat(pwszPrompt, pTempContext->pszContextName);
+           wcscat(pwszPrompt, L" ");
+       }
+    }
+    
+    // replace the last character with the prompt end character
+    pwszPrompt[wcslen(pwszPrompt) - 1] = L'>';
+    
+    StackFree(pStack, FALSE);
+    return pwszPrompt;
+}
+
+
+static
+LPCWSTR
+GetCommandAliasFromInput(
+    LPWSTR input_line,
+    SIZE_T *index)
+{
+    *index = 0;
+    LPWSTR pwszAliasValue = NULL;
+    WCHAR wChar = L'\0';
+    BOOL bRevert = FALSE;
+
+    while (input_line[*index] != L'\0')
+    {
+        wChar = input_line[*index];
+        if (iswspace(input_line[*index]))
+        {
+            input_line[*index] = L'\0';
+            bRevert = TRUE;
+            break;
+        }
+
+        (*index)++;
+    }
+
+    if (g_pHashTable != NULL)
+    {
+        pwszAliasValue = g_pHashTable->GetValue(g_pHashTable, input_line, ((*index) + 1) * sizeof(WCHAR));
+    }
+
+    if (bRevert == TRUE)
+        input_line[*index] = wChar;
+
+    return pwszAliasValue;
+}
+
+
 VOID
 InterpretInteractive(VOID)
 {
@@ -193,36 +810,79 @@ InterpretInteractive(VOID)
     BOOL bWhiteSpace = TRUE;
     BOOL bRun = TRUE;
     LPWSTR ptr;
+    LPWSTR alias_with_input_line = NULL;
+    LPWSTR pwszPrompt = NULL;
+    PCONTEXT_ENTRY pLocalCurrentContext = NULL;
+    PCONTEXT_ENTRY pRootContext = GetRootContext();
+    SIZE_T index = 0;
 
+    pLocalCurrentContext = pRootContext; // used to detect context switches
+    pwszPrompt = CreatePromptStringFromContext(pLocalCurrentContext);
+    
+    if (pwszPrompt == NULL)
+        return;
+        
     while (bRun != FALSE)
     {
         dwArgCount = 0;
         memset(args_vector, 0, sizeof(args_vector));
 
         /* Shown just before the input where the user places commands */
-//        ConResPuts(StdOut, IDS_APP_PROMPT);
-        ConPuts(StdOut, L"netsh");
-        if (pCurrentContext != pRootContext)
+        if (GetCurrentContext() != pLocalCurrentContext)
         {
-            ConPuts(StdOut, L" ");
-            ConPuts(StdOut, pCurrentContext->pszContextName);
+            HeapFree(GetProcessHeap(), 0, pwszPrompt);
+            pwszPrompt = CreatePromptStringFromContext(GetCurrentContext());
+            if (pwszPrompt == NULL)
+            {
+                ConPrintf(StdOut, L"Failed to create prompt.\n");
+                return;
+            }
+                
+            pLocalCurrentContext = GetCurrentContext();
         }
-        ConPuts(StdOut, L">");
-
+        
+        // display the prompt string
+        ConPrintf(StdOut, L"%ls", pwszPrompt);
+        
         /* Get input from the user. */
         fgetws(input_line, MAX_STRING_SIZE, stdin);
-
-        ptr = input_line;
-        while (*ptr != 0)
+        
+        LPCWSTR pwszAliasValue = GetCommandAliasFromInput(input_line, &index);
+        
+        // if it is an alias concat the value of the alias with input_line
+        if (pwszAliasValue != NULL)
         {
-            if (iswspace(*ptr) || *ptr == L'\n')
+            // Allcoate the space needed to concat the strings
+            size_t nStrSize = wcslen(pwszAliasValue) + wcslen(&input_line[index]) + 2; // two strings + space + null characters
+            alias_with_input_line = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, nStrSize * sizeof(WCHAR));
+
+            if (alias_with_input_line == NULL)
+            {
+                SetLastError(ERROR_INVALID_PARAMETER);
+                break;
+            }
+
+            // copy the alias value and input_line into alias_with_input_line
+            swprintf(alias_with_input_line, L"%ls %ls", pwszAliasValue, &input_line[index]);
+            ptr = alias_with_input_line;
+        }
+        else
+        {
+            // no alias so we can use input_line
+            ptr = input_line;
+        }
+        
+        // vectorize the string       
+        while (*ptr != L'\0')
+        {
+            if (iswspace(*ptr))
             {
                 *ptr = 0;
                 bWhiteSpace = TRUE;
             }
             else
             {
-                if ((bWhiteSpace != FALSE) && (dwArgCount < MAX_ARGS_COUNT))
+                if ((bWhiteSpace == TRUE) && (dwArgCount < MAX_ARGS_COUNT))
                 {
                     args_vector[dwArgCount] = ptr;
                     dwArgCount++;
@@ -234,5 +894,10 @@ InterpretInteractive(VOID)
 
         /* Send the string to find the command */
         bRun = InterpretCommand(args_vector, dwArgCount);
+        if (alias_with_input_line  != NULL)
+        {
+            HeapFree(GetProcessHeap(), 0, alias_with_input_line);
+            alias_with_input_line  = NULL;
+        }
     }
 }

--- a/base/applications/network/netsh/lang/en-US.rc
+++ b/base/applications/network/netsh/lang/en-US.rc
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     English (United States) resource file
  * TRANSLATOR:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+                Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
@@ -21,23 +22,52 @@ STRINGTABLE
 BEGIN
     IDS_HELP_HEADER "\nThe following commands are available:\n"
     IDS_SUBCONTEXT_HEADER "\nThe following sub-contexts are available:\n"
-    IDS_HLP_UP             "Goes up one context level."
+    IDS_HLP_UP             "Goes up one context level.\n"
     IDS_HLP_UP_EX          "Syntax: ..\n\n        Goes up one context level.\n\n"
-    IDS_HLP_EXIT           "Exits the program."
+    IDS_HLP_EXIT           "Exits the program.\n"
     IDS_HLP_EXIT_EX        "Syntax: exit\n\n        Exits the program.\n\n"
-    IDS_HLP_HELP           "Displays a list of commands."
+    IDS_HLP_HELP           "Displays a list of commands.\n"
     IDS_HLP_HELP_EX        "Syntax: help\n\n        Displays a list of commands.\n\n"
 
-    IDS_HLP_ADD_HELPER     "Installs a helper DLL."
+    IDS_HLP_ADD_HELPER     "Installs a helper DLL.\n"
     IDS_HLP_ADD_HELPER_EX  "Syntax: add helper <dll file name>\n\n        Installs the specified helper DLL in netsh.\n\n"
 
-    IDS_HLP_DEL_HELPER     "Removes a helper DLL."
+    IDS_HLP_DEL_HELPER     "Removes a helper DLL.\n"
     IDS_HLP_DEL_HELPER_EX  "Syntax: delete helper <dll file name>\n\n        Removes the specified helper DLL from netsh.\n\n"
 
-    IDS_HLP_SHOW_HELPER    "Lists all the top-level helpers."
+    IDS_HLP_SHOW_HELPER    "Lists all the top-level helpers.\n"
     IDS_HLP_SHOW_HELPER_EX "Syntax: show helper\n\n        Lists all the top-level helpers.\n\n"
 
-    IDS_HLP_GROUP_ADD      "Adds a configuration entry to a list of entries."
-    IDS_HLP_GROUP_DELETE   "Deletes a configuration entry from a list of entries."
-    IDS_HLP_GROUP_SHOW     "Displays information."
+    IDS_HLP_GROUP_ADD      "Adds a configuration entry to a list of entries.\n"
+    IDS_HLP_GROUP_DELETE   "Deletes a configuration entry from a list of entries.\n"
+    IDS_HLP_GROUP_SHOW     "Displays information.\n"
+    IDS_HLP_GROUP_SET      "Updates configuration settings.\n"
+    
+    IDS_HLP_ABORT          "Discards changes made while in offline mode.\n"
+    IDS_HLP_ABORT_EX       "TODO IDS_HLP_ABORT_EX\n"
+    IDS_HLP_ALIAS          "Adds an alias.\n"
+    IDS_HLP_ALIAS_EX       "TODO IDS_HLP_ALIAS_EX\n"
+   
+   IDS_HLP_COMMIT          "Commits changes made while in offline mode.\n"                      
+   IDS_HLP_COMMIT_EX       "TODO IDS_HLP_COMMIT_EX\n"
+   IDS_HLP_DUMP            "Displays a configuration script.\n"            
+   IDS_HLP_DUMP_EX         "TODO IDS_HLP_DUMP_EX\n"
+   IDS_HLP_EXEC            "Runs a script file.\n"
+   IDS_HLP_EXEC_EX         "TODO IDS_HLP_EXEC_EX\n"
+   
+   IDS_HLP_PUSHD           "Pushes current context on stack.\n"           
+   IDS_HLP_PUSHD_EX        "TODO IDS_HLP_PUSHD_EX\n"
+   IDS_HLP_POPD            "Pops a context from the stack.\n"
+   IDS_HLP_POPD_EX         "TODO IDS_HLP_POPD_EX\n"
+   IDS_HLP_OFFLINE         "Sets the current mode to offline.\n"
+   IDS_HLP_OFFLINE_EX      "TODO IDS_HLP_OFFLINE_EX\n"
+   IDS_HLP_ONLINE          "Sets the current mode to online.\n"
+   IDS_HLP_ONLINE_EX       "TODO IDS_HLP_ONLINE_EX\n"
+   IDS_HLP_UNALIAS         "Deletes an alias.\n"
+   IDS_HLP_UNALIAS_EX      "TODO IDS_HLP_UNALIAS_EX\n"
+   
+   IDS_HLP_SET_MACHINE     "Sets the current machine on which to operate.\n"
+   IDS_HLP_SET_MACHINE_EX  "TODO IDS_HLP_SET_MACHINE_EX\n"
+   IDS_HLP_SET_MODE        "Sets the current mode to online or offline.\n"
+   IDS_HLP_SET_MODE_EX     "TODO IDS_HLP_SET_MODE_EX\n"
 END

--- a/base/applications/network/netsh/list.c
+++ b/base/applications/network/netsh/list.c
@@ -1,0 +1,220 @@
+/*
+ * PROJECT:    ReactOS NetSh
+ * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:    List code
+ * COPYRIGHT:  Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
+ */
+ 
+#include "precomp.h"
+#define NDEBUG
+#include <debug.h>
+
+
+static BOOL _AddToList(PLIST self, PVOID data);
+static BOOL _RemoveFromList(PLIST self, PVOID data);
+static BOOL _RemoveItem(PLIST self, size_t index); // Changed to size_t
+static size_t _CountOfList(PLIST self); // Changed to size_t
+static PVOID _PopFromList(PLIST self);
+static VOID _FreeList(PLIST self);
+static PLIST_NODE _GetItem(PLIST self, size_t index); // Changed to size_t
+
+
+// Function implementations
+static 
+BOOL 
+_AddToList(
+    PLIST self, 
+    PVOID data) 
+{
+    if (!self || !data)
+    {
+        DPRINT1("%s self or data is NULL\n", __FUNCTION__); 
+        return FALSE;
+    }
+
+    PLIST_NODE newNode = (PLIST_NODE)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(LIST_NODE));
+    if (!newNode) 
+    {
+        DPRINT1("%s newNode is NULL!\n", __FUNCTION__);
+        return FALSE;
+    }
+    
+    newNode->Data = data;
+    newNode->Next = self->Head;
+    self->Head = newNode;
+    self->NodeCount++;
+    return TRUE;
+}
+
+
+static 
+BOOL 
+_RemoveFromList(
+    PLIST self, 
+    PVOID data) 
+{
+    if (!self || !data || !self->Head) 
+        return FALSE;
+
+    PLIST_NODE current = self->Head;
+    PLIST_NODE previous = NULL;
+
+    while (current) {
+        if (current->Data == data) {
+            if (previous) {
+                previous->Next = current->Next;
+            } else {
+                self->Head = current->Next;
+            }
+            HeapFree(GetProcessHeap(), 0, current);
+            self->NodeCount--;
+            return TRUE;
+        }
+        previous = current;
+        current = current->Next;
+    }
+    return FALSE;
+}
+
+
+static 
+BOOL 
+_RemoveItem(
+    PLIST self, 
+    size_t index) 
+{
+    if (!self || index >= self->NodeCount) 
+        return FALSE;
+
+    PLIST_NODE current = self->Head;
+    PLIST_NODE previous = NULL;
+
+    if (index == 0) {
+        // Special case: Remove the head node
+        self->Head = current->Next;
+        HeapFree(GetProcessHeap(), 0, current);
+        self->NodeCount--;
+        return TRUE;
+    }
+
+    for (size_t i = 0; i < index; i++) {
+        previous = current;
+        current = current->Next;
+    }
+
+    if (current) {
+        previous->Next = current->Next;
+        HeapFree(GetProcessHeap(), 0, current);
+        self->NodeCount--;
+        return TRUE;
+    }
+
+    return FALSE; // If we reach here, the index was invalid
+}
+
+
+static 
+size_t 
+_CountOfList(
+    PLIST self) 
+{
+    DPRINT1("%s() \n", __FUNCTION__);
+    if (self == NULL)
+    {
+        DPRINT1("%s self is NULL!\n", __FUNCTION__); 
+        return 0;
+    }
+    
+    DPRINT1("%s self->NodeCount\n", __FUNCTION__);
+    return self->NodeCount;
+}
+
+
+static 
+PVOID 
+_PopFromList(
+    PLIST self) 
+{
+    if (!self || !self->Head) 
+        return NULL;
+
+    PLIST_NODE nodeToPop = self->Head;
+    self->Head = nodeToPop->Next;
+    self->NodeCount--;
+
+    PVOID data = nodeToPop->Data;
+    HeapFree(GetProcessHeap(), 0, nodeToPop);
+    return data;
+}
+
+
+static 
+VOID 
+_FreeList(
+    PLIST self) 
+{
+    if (!self) 
+        return;
+
+    PLIST_NODE current = self->Head;
+    while (current) 
+    {
+        PLIST_NODE next = current->Next;
+        HeapFree(GetProcessHeap(), 0, current);
+        current = next;
+    }
+    HeapFree(GetProcessHeap(), 0, self);
+}
+
+
+static 
+PLIST_NODE 
+_GetItem(
+    PLIST self, 
+    size_t index) 
+{
+    
+    if ((self == NULL) || (index >= self->NodeCount))
+    {
+        DPRINT1("%s self is NULL, or index >= NodeCount\n", __FUNCTION__);
+        return NULL;
+    }
+
+    PLIST_NODE current = self->Head;
+    size_t currentIndex = 0;
+    
+    while (current && currentIndex < index) 
+    {
+        current = current->Next;
+        currentIndex++;
+    }
+
+    return current; // Returns NULL if the index is out of bounds
+}
+
+
+PLIST 
+CreateList() 
+{
+    DPRINT("%s()\n", __FUNCTION__);
+    PLIST list = (PLIST)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(LIST));
+    if (list) 
+    {
+        list->Head = NULL;
+        list->NodeCount = 0;
+
+        list->Add = _AddToList;
+        list->Remove = _RemoveFromList;
+        list->RemoveItem = _RemoveItem;
+        list->Count = _CountOfList;
+        list->Pop = _PopFromList;
+        list->Free = _FreeList;
+        list->GetItem = _GetItem;
+    }
+    else
+    {
+        DPRINT1("%s List is NULL!\n", __FUNCTION__);
+    }
+    
+    return list;
+}

--- a/base/applications/network/netsh/netsh.c
+++ b/base/applications/network/netsh/netsh.c
@@ -3,6 +3,7 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell main file
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 /* INCLUDES *******************************************************************/
@@ -12,12 +13,36 @@
 #define NDEBUG
 #include <debug.h>
 
+
+/* Globals *********************************************************************/
+
+static BOOL gbOnline = TRUE; 
+
 /* FUNCTIONS ******************************************************************/
+
+
+/*
+bOnline TRUE to turn online
+bOnline FALSE to turn offline
+*/
+void
+SetMode(
+    BOOL bOnline)
+{
+    gbOnline = bOnline;
+}
+
+BOOL
+GetMode(VOID)
+{
+    return gbOnline;
+}
 
 BOOL
 RunScript(
     _In_ LPCWSTR filename)
 {
+    DPRINT("%s\n", __FUNCTION__);
     FILE *script;
     WCHAR tmp_string[MAX_STRING_SIZE];
 
@@ -54,6 +79,7 @@ wmain(
     _In_ int argc,
     _In_ const LPWSTR argv[])
 {
+    DPRINT("%s\n", __FUNCTION__);
     LPCWSTR tmpBuffer = NULL;
     LPCWSTR pszFileName = NULL;
     int index;
@@ -152,6 +178,11 @@ wmain(
             else if (_wcsicmp(tmpBuffer, L"r") == 0)
             {
                 /* Remote option */
+                /*
+                LogonUserW(lpszUsername, lpszDomain, lpszPassword ,LOGON32_LOGON_NEW_CREDENTIALS, LOGON32_PROVIDER_DEFAULT, phToken);
+                ImpersonateLoggedOnUser(phToken);
+                RevertToSelf();
+                */
                 if ((index + 1) < argc)
                 {
                     index++;
@@ -201,18 +232,41 @@ MatchEnumTag(
     _In_ const TOKEN_VALUE *pEnumTable,
     _Out_ PDWORD pdwValue)
 {
-    DPRINT1("MatchEnumTag()\n");
+    DPRINT("MatchEnumTag()\n");
     return 0;
 }
 
+/*
+The MatchToken function determines whether a user-entered string matches a specific string. 
+A match exists if the user-entered string is a case-insensitive prefix of the specific string.
+*/
 BOOL
 WINAPI
 MatchToken(
     _In_ LPCWSTR pwszUserToken,
-    _In_ LPCWSTR pwszCmdToken)
+    _In_ LPCWSTR pwszCmdToken) 
 {
-    DPRINT1("MatchToken %S %S\n", pwszUserToken, pwszCmdToken);
-    return (_wcsicmp(pwszUserToken, pwszCmdToken) == 0) ? TRUE : FALSE;
+
+    // Check for NULL pointers
+    if (pwszUserToken == NULL || pwszCmdToken == NULL) 
+    {
+        DPRINT1("%s string pointers are NULL!\n", __FUNCTION__);
+        return FALSE;
+    }
+    
+    DPRINT("MatchToken %S %S\n", pwszUserToken, pwszCmdToken);
+    
+    // Get the lengths of lpszStr and lpszSubstr
+    size_t nUserTokenLength = wcslen(pwszUserToken);
+    size_t nCmdTokenLength = wcslen(pwszCmdToken);
+    
+    if (nUserTokenLength > nCmdTokenLength) 
+    {
+        DPRINT1("%s nUserTokenLength > nCmdTokenLength\n", __FUNCTION__);
+        return FALSE;
+    }
+
+    return (_wcsnicmp(pwszCmdToken, pwszUserToken, nUserTokenLength) == 0) ? TRUE : FALSE;
 }
 
 DWORD
@@ -222,8 +276,39 @@ PrintError(
     _In_ DWORD dwErrId,
     ...)
 {
-    DPRINT1("PrintError()\n");
-    return 1;
+    WCHAR *lpBuffer = NULL;
+    INT Length;
+    
+    // if hModule is not null print a string from a module
+    if (hModule != NULL)
+    {
+        va_list ap;
+        va_start(ap, dwErrId);
+        Length = PrintMessageFromModule(hModule, dwErrId, ap);
+        va_end(ap);   
+    }
+    // if hModule is NULL then we need to treat dwErrId as an error code
+    // found in the system-message table
+    else
+    {
+        FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER,
+                      NULL,
+                      dwErrId,
+                      0,
+                      (LPWSTR)&lpBuffer,
+                      0,
+                      NULL);
+        // print the message
+        va_list ap;
+        va_start(ap, dwErrId);
+        Length = ConPrintf(StdOut, lpBuffer);
+        va_end(ap);
+        // When FORMAT_MESSAGE_ALLOCATE_BUFFER is used with FormatMessage
+        // its up to the caller to free it with LocalFree
+        LocalFree(lpBuffer);
+    }
+    return Length;
+    
 }
 
 DWORD
@@ -233,8 +318,58 @@ PrintMessageFromModule(
     _In_ DWORD  dwMsgId,
     ...)
 {
-    DPRINT1("PrintMessageFromModule()\n");
-    return 1;
+    DPRINT1("%s()\n", __FUNCTION__);
+    WCHAR *lpBuffer = NULL;
+    INT Length = 0;
+    int nBytesRead = 0;
+    
+    if (hModule == NULL)
+        goto end;
+    
+    // LoadStringW when given a size of 0 returns a read only pointer
+    // to a resource string    
+    nBytesRead = LoadStringW(hModule, dwMsgId, (LPWSTR)&lpBuffer, 0);
+ 
+    if ( lpBuffer != NULL)
+    {
+
+        // check if the resource string is NULL terminated
+        if(lpBuffer[nBytesRead] == UNICODE_NULL)
+        {  
+            va_list ap;
+            va_start(ap, dwMsgId);
+            Length = ConPrintfV(StdOut, lpBuffer, ap);
+            va_end(ap);
+        }
+        // if its not null terminated, create a null terminated copy of the string to print
+        else
+        {
+            // Allocate a string buffer of size nBytesREad + 1 because LoadStringW
+            // does not count the NULL character
+            WCHAR *lpBuffer2 = (WCHAR *)HeapAlloc(GetProcessHeap(), 
+                                                  HEAP_ZERO_MEMORY, 
+                                                  (nBytesRead + 1) * sizeof(WCHAR));
+            if (lpBuffer2 == NULL)
+            {
+                DPRINT("%s space for lpBuffer2 could not be allocated\n", __FUNCTION__); 
+                SetLastError(ERROR_OUTOFMEMORY);
+                Length = 0;
+                goto end;
+            }
+            
+            // copy the lpBuffer to lpBuffer2
+            StringCchCopyW(lpBuffer2, nBytesRead + 1, lpBuffer);
+
+            va_list ap;
+            va_start(ap, dwMsgId);
+            Length = ConPrintfV(StdOut, lpBuffer2, ap);
+            va_end(ap);
+            HeapFree(GetProcessHeap(), 0, lpBuffer2);
+        }    
+    }
+
+    end:
+    return Length;
 }
 
 DWORD
@@ -247,7 +382,7 @@ PrintMessage(
     va_list ap;
 
     va_start(ap, pwszFormat);
-    Length = ConPrintf(StdOut, pwszFormat);
+    Length = ConPrintfV(StdOut, pwszFormat, ap);
     va_end(ap);
 
     return Length;

--- a/base/applications/network/netsh/precomp.h
+++ b/base/applications/network/netsh/precomp.h
@@ -3,6 +3,7 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell main header file
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 #ifndef PRECOMP_H
@@ -13,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <wchar.h>
 
 #define WIN32_NO_STATUS
 #include <windef.h>
@@ -24,10 +26,11 @@
 #include <errno.h>
 
 #include <conutils.h>
+#include <strsafe.h>
 #include <netsh.h>
 
 #include "resource.h"
-
+#include "hashtable.h"
 
 /* DEFINES *******************************************************************/
 
@@ -36,8 +39,76 @@
 
 #define REG_NETSH_PATH L"Software\\Microsoft\\NetSh"
 
+//todo add to netsh.h
+#define NETSH_ERROR_BASE                        15000
+#define ERROR_NO_ENTRIES                        (NETSH_ERROR_BASE + 0)
+#define ERROR_INVALID_SYNTAX                    (NETSH_ERROR_BASE + 1)
+#define ERROR_PROTOCOL_NOT_IN_TRANSPORT         (NETSH_ERROR_BASE + 2)
+#define ERROR_NO_CHANGE                         (NETSH_ERROR_BASE + 3)
+#define ERROR_CMD_NOT_FOUND                     (NETSH_ERROR_BASE + 4)
+#define ERROR_ENTRY_PT_NOT_FOUND                (NETSH_ERROR_BASE + 5)
+#define ERROR_DLL_LOAD_FAILED                   (NETSH_ERROR_BASE + 6)
+#define ERROR_INIT_DISPLAY                      (NETSH_ERROR_BASE + 7)
+#define ERROR_TAG_ALREADY_PRESENT               (NETSH_ERROR_BASE + 8)
+#define ERROR_INVALID_OPTION_TAG                (NETSH_ERROR_BASE + 9)
+#define ERROR_NO_TAG                            (NETSH_ERROR_BASE + 10)
+#define ERROR_MISSING_OPTION                    (NETSH_ERROR_BASE + 11)
+#define ERROR_TRANSPORT_NOT_PRESENT             (NETSH_ERROR_BASE + 12)
+#define ERROR_SHOW_USAGE                        (NETSH_ERROR_BASE + 13)
+#define ERROR_INVALID_OPTION_VALUE              (NETSH_ERROR_BASE + 14)
+#define ERROR_OKAY                              (NETSH_ERROR_BASE + 15)
+#define ERROR_CONTINUE_IN_PARENT_CONTEXT        (NETSH_ERROR_BASE + 16)
+#define ERROR_SUPPRESS_OUTPUT                   (NETSH_ERROR_BASE + 17)
+#define ERROR_HELPER_ALREADY_REGISTERED         (NETSH_ERROR_BASE + 18)
+#define ERROR_CONTEXT_ALREADY_REGISTERED        (NETSH_ERROR_BASE + 19)
+#define ERROR_PARSING_FAILURE                   (NETSH_ERROR_BASE + 20) 
+#define NETSH_ERROR_END                ERROR_CONTEXT_ALREADY_REGISTERED
 
 /* TYPEDEFS ******************************************************************/
+
+// TODO move to netsh.h
+enum NS_CMD_FLAGS
+{
+    CMD_FLAG_PRIVATE     = 0x01, // not valid in sub-contexts
+    CMD_FLAG_INTERACTIVE = 0x02, // not valid from outside netsh
+    CMD_FLAG_LOCAL       = 0x08, // not valid from a remote machine
+    CMD_FLAG_ONLINE      = 0x10, // not valid in offline/non-commit mode
+    CMD_FLAG_HIDDEN      = 0x20, // hide from help but allow execution
+    CMD_FLAG_LIMIT_MASK  = 0xffff,
+    CMD_FLAG_PRIORITY    = 0x80000000 // ulPriority field is used*/
+};
+
+
+typedef struct _LIST_NODE 
+{
+    PVOID Data;
+    struct _LIST_NODE *Next;
+} LIST_NODE, *PLIST_NODE;
+
+typedef struct _LIST 
+{
+    PLIST_NODE Head;
+    size_t NodeCount;
+    BOOL (*Add)(struct _LIST *self, PVOID data);
+    BOOL (*Remove)(struct _LIST *self, PVOID data);
+    BOOL (*RemoveItem)(struct _LIST *self, size_t index);
+    size_t (*Count)(struct _LIST *self);
+    PVOID (*Pop)(struct _LIST *self);
+    VOID (*Free)(struct _LIST *self);
+    PLIST_NODE (*GetItem)(struct _LIST *self, size_t index);
+} LIST, *PLIST;
+
+
+typedef struct _STACK_NODE 
+{
+    void *pData;
+    struct _STACK_NODE* pNext;
+} STATCK_NODE;
+
+
+typedef struct _STACK {
+    STATCK_NODE* pTop; 
+} STACK;
 
 typedef struct _DLL_LIST_ENTRY
 {
@@ -61,13 +132,12 @@ typedef struct _HELPER_ENTRY
 
     PDLL_LIST_ENTRY pDllEntry;
     BOOL bStarted;
+    const GUID *pguidParentHelper;
 
     struct _HELPER_ENTRY *pSubHelperHead;
     struct _HELPER_ENTRY *pSubHelperTail;
 
 } HELPER_ENTRY, *PHELPER_ENTRY;
-
-
 
 typedef struct _COMMAND_ENTRY
 {
@@ -79,6 +149,9 @@ typedef struct _COMMAND_ENTRY
     DWORD dwShortCmdHelpToken;
     DWORD dwCmdHlpToken;
     DWORD dwFlags;
+    PNS_OSVERSIONCHECK pOsVersionCheck;
+    HMODULE hModule;
+    
 } COMMAND_ENTRY, *PCOMMAND_ENTRY;
 
 typedef struct _COMMAND_GROUP
@@ -88,8 +161,11 @@ typedef struct _COMMAND_GROUP
 
     LPCWSTR pwszCmdGroupToken;
     DWORD dwShortCmdHelpToken;
+    ULONG ulCmdGroupSize;
     DWORD dwFlags;
-
+    PNS_OSVERSIONCHECK pOsVersionCheck;
+    HMODULE hModule;
+    
     PCOMMAND_ENTRY pCommandListHead;
     PCOMMAND_ENTRY pCommandListTail;
 } COMMAND_GROUP, *PCOMMAND_GROUP;
@@ -118,8 +194,8 @@ typedef struct _CONTEXT_ENTRY
 
 /* GLOBAL VARIABLES ***********************************************************/
 
-extern PCONTEXT_ENTRY pRootContext;
-extern PCONTEXT_ENTRY pCurrentContext;
+//extern PCONTEXT_ENTRY pRootContext;
+//extern PCONTEXT_ENTRY pCurrentContext;
 
 
 /* PROTOTYPES *****************************************************************/
@@ -128,6 +204,16 @@ extern PCONTEXT_ENTRY pCurrentContext;
 
 BOOL
 CreateRootContext(VOID);
+
+PCONTEXT_ENTRY
+GetCurrentContext(VOID);
+
+void
+SetCurrentContext(
+    PCONTEXT_ENTRY pContext);
+
+PCONTEXT_ENTRY
+GetRootContext(VOID);
 
 
 /* help.c */
@@ -141,6 +227,11 @@ HelpCommand(
     DWORD dwFlags,
     LPCVOID pvData,
     BOOL *pbDone);
+    
+VOID
+HelpContext(
+    PCONTEXT_ENTRY pContext);
+
 
 VOID
 HelpGroup(
@@ -176,6 +267,10 @@ DeleteHelperCommand(
     DWORD dwFlags,
     LPCVOID pvData,
     BOOL *pbDone);
+    
+    
+PHELPER_ENTRY
+FindHelper(const GUID *pguidHelper);
 
 DWORD
 WINAPI
@@ -191,6 +286,10 @@ ShowHelperCommand(
 
 /* interpreter.c */
 BOOL
+CallOsVersionCheck(
+    PNS_OSVERSIONCHECK NsOsversioncheck);
+
+BOOL
 InterpretScript(
     LPWSTR pszFileName);
 
@@ -199,7 +298,80 @@ InterpretCommand(
     LPWSTR *argv,
     DWORD dwArgCount);
 
+
+VOID
+DisplayAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength);
+
+
+VOID
+DisplayAliasTable();
+
+
+BOOL
+SetAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength, 
+    PVOID pValue);
+
+
+BOOL
+DeleteAliasEntry(
+    PVOID pKey, 
+    SIZE_T nKeyLength);
+    
+
 VOID
 InterpretInteractive(VOID);
+
+/* list.c */
+PLIST 
+CreateList();
+
+/* netsh.c */
+void
+SetMode(
+    BOOL bOnline);
+    
+    
+BOOL
+GetMode(VOID);
+
+/* stack.c */
+STACK* 
+CreateStack(void);
+
+
+void 
+StackPush(
+    STACK *pStack, 
+    void *pData) ;
+
+
+void* 
+StackPop(
+    STACK *pStack) ;
+
+
+void* 
+StackPeek(
+    STACK* pStack);
+
+
+void 
+StackFree(
+    STACK *pStack, 
+    BOOL bFreeData);
+
+
+BOOL 
+IsStackEmpty(STACK *pStack);
+
+/* utility.c */
+PWSTR JoinStringsW(
+    PWSTR* ppwszStrings, 
+    size_t sizeCount, 
+    PCWSTR pcwszSeparator);
 
 #endif /* PRECOMP_H */

--- a/base/applications/network/netsh/resource.h
+++ b/base/applications/network/netsh/resource.h
@@ -3,6 +3,7 @@
  * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:    Network Shell resource id header file
  * COPYRIGHT:  Copyright 2023 Eric Kohl <eric.kohl@reactos.org>
+               Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
  */
 
 #pragma once
@@ -35,3 +36,32 @@
 #define IDS_HLP_GROUP_ADD        320
 #define IDS_HLP_GROUP_DELETE     321
 #define IDS_HLP_GROUP_SHOW       322
+#define IDS_HLP_GROUP_SET        323
+
+
+#define IDS_HLP_ABORT            330
+#define IDS_HLP_ABORT_EX         331
+#define IDS_HLP_ALIAS            332
+#define IDS_HLP_ALIAS_EX         333
+#define IDS_HLP_COMMIT           334
+#define IDS_HLP_COMMIT_EX        335
+#define IDS_HLP_DUMP             336
+#define IDS_HLP_DUMP_EX          337
+#define IDS_HLP_EXEC             338
+#define IDS_HLP_EXEC_EX          339
+
+#define IDS_HLP_PUSHD            340
+#define IDS_HLP_PUSHD_EX         341
+#define IDS_HLP_POPD             342
+#define IDS_HLP_POPD_EX          343
+#define IDS_HLP_OFFLINE          344
+#define IDS_HLP_OFFLINE_EX       345
+#define IDS_HLP_ONLINE           346
+#define IDS_HLP_ONLINE_EX        347
+#define IDS_HLP_UNALIAS          348
+#define IDS_HLP_UNALIAS_EX       349
+
+#define IDS_HLP_SET_MACHINE      350
+#define IDS_HLP_SET_MACHINE_EX   351
+#define IDS_HLP_SET_MODE         352
+#define IDS_HLP_SET_MODE_EX      353

--- a/base/applications/network/netsh/stack.c
+++ b/base/applications/network/netsh/stack.c
@@ -1,0 +1,120 @@
+/*
+ * PROJECT:    ReactOS NetSh
+ * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:    Stack code
+ * COPYRIGHT:  Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "precomp.h"
+
+#define NDEBUG
+#include <debug.h>
+STACK* 
+CreateStack() 
+{
+    DPRINT1("%s()\n",  __FUNCTION__);
+    STACK* pStack = (STACK*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(STACK));
+    if (pStack == NULL) {
+        DPRINT1("%s Memory allocation failed\n",  __FUNCTION__);
+        return NULL;
+    }
+    pStack->pTop = NULL;
+    return pStack;
+}
+
+
+void 
+StackPush(STACK *pStack, void *pData) 
+{
+    DPRINT1("%s()\n",  __FUNCTION__);
+    if (pStack == NULL)
+    {
+        DPRINT1("%s Stack is NULL\n",  __FUNCTION__);
+        return;
+    }
+    
+    STATCK_NODE *pNewNode = (STATCK_NODE*)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(STATCK_NODE));
+    if (pNewNode == NULL) 
+    {
+        DPRINT1("%s Memory allocation failed\n",  __FUNCTION__);
+        return;
+    }
+    
+    pNewNode->pData = pData;
+    pNewNode->pNext = pStack->pTop;
+    pStack->pTop = pNewNode;
+}
+
+
+void* 
+StackPop(STACK *pStack) 
+{
+    DPRINT1("%s()\n",  __FUNCTION__);
+    
+    if (pStack == NULL)
+    {
+        DPRINT1("%s Stack is NULL\n",  __FUNCTION__);
+        return NULL;
+    }
+    
+    if (pStack->pTop == NULL) 
+    {
+        DPRINT1("%s Stack is empty\n",  __FUNCTION__);
+        return NULL;
+    }
+    
+    STATCK_NODE *pTempNode = pStack->pTop;
+    void *pPoppedEntry = pTempNode->pData;
+    pStack->pTop = pStack->pTop->pNext;
+    HeapFree(GetProcessHeap(), 0, pTempNode); // Free the stack node
+    
+    return pPoppedEntry;
+}
+
+
+void* 
+StackPeek(STACK* pStack) 
+{
+    DPRINT1("%s()\n",  __FUNCTION__);
+    
+    if (pStack->pTop == NULL) 
+    {
+        DPRINT1("%s Stack is empty\n", __FUNCTION__);
+        return NULL;
+    }
+    return pStack->pTop->pData;
+}
+
+
+void 
+StackFree(STACK *pStack, BOOL bFreeData) 
+{
+    DPRINT1("%s()\n",  __FUNCTION__);
+    
+    STATCK_NODE* pCurrent = pStack->pTop;
+    STATCK_NODE* pNextNode;
+    
+    while (pCurrent != NULL) 
+    {
+        pNextNode = pCurrent->pNext;
+        
+        if (bFreeData == TRUE)
+            HeapFree(GetProcessHeap(), 0, pCurrent->pData);
+            
+        HeapFree(GetProcessHeap(), 0, pCurrent);
+        pCurrent = pNextNode;
+    }
+    
+    HeapFree(GetProcessHeap(), 0, pStack);
+}
+
+BOOL IsStackEmpty(STACK *pStack)
+{
+    if (pStack != NULL)
+        return (pStack->pTop == NULL) ? TRUE : FALSE;
+        
+    return TRUE;
+}
+

--- a/base/applications/network/netsh/utility.c
+++ b/base/applications/network/netsh/utility.c
@@ -1,0 +1,63 @@
+/*
+ * PROJECT:    ReactOS NetSh
+ * LICENSE:    GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:    Helper functions used thoughout the program
+ * COPYRIGHT:  Copyright 2025 Curtis Wilson <LiquidFox1776@gmail.com>
+ */
+ 
+ #include "precomp.h"
+ #define NDEBUG
+ #include <debug.h>
+ /*
+ GUID *
+ GuidFromStringW(LPCWSTR lpwszString)
+ {
+ 
+ }
+ 
+ LPCWSTR
+ StringFromGuidW(GUID * pGuid)
+ {
+ 
+ }
+ 
+ */
+ 
+ PWSTR JoinStringsW(
+    PWSTR* ppwszStrings, 
+    size_t sizeCount, 
+    PCWSTR pcwszSeparator) 
+{
+    size_t sizeLength = 0;
+
+    if (sizeCount == 0) 
+        return NULL;
+
+    if (pcwszSeparator == NULL)
+        return NULL;
+
+    for (size_t index = 0; index < sizeCount; index++) {
+        sizeLength += wcslen(ppwszStrings[index]);
+    }
+
+    sizeLength += wcslen(pcwszSeparator) * (sizeCount - 1);
+
+    HANDLE hHeap = GetProcessHeap();
+    if (hHeap == NULL) 
+        return NULL;
+
+    PWSTR pwszResult = (PWSTR)HeapAlloc(hHeap, HEAP_ZERO_MEMORY, (sizeLength + 1) * sizeof(wchar_t));
+    if (pwszResult == NULL) 
+        return NULL;
+
+    // start the string
+    wcscpy(pwszResult, ppwszStrings[0]);
+    // join the rest of the strings
+    for (size_t index = 1; index < sizeCount; index++) 
+    {
+        wcscat(pwszResult, pcwszSeparator);
+        wcscat(pwszResult, ppwszStrings[index]);
+    }
+
+    return pwszResult;
+}


### PR DESCRIPTION
- Modified the command interpreter to behave more like the versions found in Windows by implementing a FSM that allows for:
--Hierarchical traversal of contexts and command execution 
-- Command inheritance 
-- Processing of some of the NS_CMD_FLAGS 
-- OsVersionCheck support

- Added more built-in commands
- Updated the resource file
- Implemented a hash table to support the alias and unalias commands
- Implemented PrintMessageFromModule
- Implemented PrintError
- Changed the MatchToken function to match the specifications found in Microsofts Win32 documentation

This utility still needs a lot more work.